### PR TITLE
fix(pool config): update the ROThresholdLimit data type

### DIFF
--- a/pkg/apis/cstor/v1/cstorpoolcluster.go
+++ b/pkg/apis/cstor/v1/cstorpoolcluster.go
@@ -127,8 +127,8 @@ type PoolConfig struct {
 	// NOTE:
 	// 1. If ROThresholdLimit is set to 100 then entire
 	//    pool storage will be used by default it will be set to 85%.
-	// 2. ROThresholdLimit value will be 0 < ROThresholdLimit <= 100.
-	ROThresholdLimit int `json:"roThresholdLimit"` //optional
+	// 2. ROThresholdLimit value will be 0 <= ROThresholdLimit <= 100.
+	ROThresholdLimit *int `json:"roThresholdLimit"` //optional
 }
 
 // RaidGroup contains the details of a raid group for the pool

--- a/pkg/apis/cstor/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/cstor/v1/zz_generated.deepcopy.go
@@ -959,6 +959,11 @@ func (in *PoolConfig) DeepCopyInto(out *PoolConfig) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.ROThresholdLimit != nil {
+		in, out := &in.ROThresholdLimit, &out.ROThresholdLimit
+		*out = new(int)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/internalapis/apis/cstor/cstorpoolcluster.go
+++ b/pkg/internalapis/apis/cstor/cstorpoolcluster.go
@@ -127,8 +127,8 @@ type PoolConfig struct {
 	// NOTE:
 	// 1. If ROThresholdLimit is set to 100 then entire
 	//    pool storage will be used by default it will be set to 85%.
-	// 2. ROThresholdLimit value will be 0 < ROThresholdLimit <= 100.
-	ROThresholdLimit int `json:"roThresholdLimit"` //optional
+	// 2. ROThresholdLimit value will be 0 <= ROThresholdLimit <= 100.
+	ROThresholdLimit *int `json:"roThresholdLimit"` //optional
 }
 
 // RaidGroup contains the details of a raid group for the pool

--- a/pkg/internalapis/apis/cstor/v1/zz_generated.conversion.go
+++ b/pkg/internalapis/apis/cstor/v1/zz_generated.conversion.go
@@ -1501,7 +1501,7 @@ func autoConvert_v1_PoolConfig_To_cstor_PoolConfig(in *v1.PoolConfig, out *cstor
 	out.AuxResources = (*corev1.ResourceRequirements)(unsafe.Pointer(in.AuxResources))
 	out.Tolerations = *(*[]corev1.Toleration)(unsafe.Pointer(&in.Tolerations))
 	out.PriorityClassName = in.PriorityClassName
-	out.ROThresholdLimit = in.ROThresholdLimit
+	out.ROThresholdLimit = (*int)(unsafe.Pointer(in.ROThresholdLimit))
 	return nil
 }
 
@@ -1519,7 +1519,7 @@ func autoConvert_cstor_PoolConfig_To_v1_PoolConfig(in *cstor.PoolConfig, out *v1
 	out.AuxResources = (*corev1.ResourceRequirements)(unsafe.Pointer(in.AuxResources))
 	out.Tolerations = *(*[]corev1.Toleration)(unsafe.Pointer(&in.Tolerations))
 	out.PriorityClassName = in.PriorityClassName
-	out.ROThresholdLimit = in.ROThresholdLimit
+	out.ROThresholdLimit = (*int)(unsafe.Pointer(in.ROThresholdLimit))
 	return nil
 }
 

--- a/pkg/internalapis/apis/cstor/zz_generated.deepcopy.go
+++ b/pkg/internalapis/apis/cstor/zz_generated.deepcopy.go
@@ -937,6 +937,11 @@ func (in *PoolConfig) DeepCopyInto(out *PoolConfig) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.ROThresholdLimit != nil {
+		in, out := &in.ROThresholdLimit, &out.ROThresholdLimit
+		*out = new(int)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>
This PR updates the ROThresholdLimit data type from int to *int.
It will help to resolve the ambiguity between whether user-specified or defaulted value.