### PR TITLE
chore(cspc): update cspc api

### DIFF
--- a/pkg/apis/cstor/v1/cstorpoolcluster.go
+++ b/pkg/apis/cstor/v1/cstorpoolcluster.go
@@ -99,9 +99,9 @@ type PoolConfig struct {
 	// WriteCacheGroupType is the write cache raid type.
 	WriteCacheGroupType string `json:"writeCacheGroupType"`
 
-	// ThickProvisioning to enable thick provisioning
+	// ThickProvision to enable thick provisioning
 	// Optional -- defaults to false
-	ThickProvisioning bool `json:"thickProvisioning"`
+	ThickProvision bool `json:"thickProvision"`
 	// Compression to enable compression
 	// Optional -- defaults to off
 	// Possible values : lz, off
@@ -164,6 +164,13 @@ type CStorPoolClusterStatus struct {
 }
 
 type CSPCConditionType string
+
+// These are valid conditions of a cspc.
+const (
+	// PoolManagerAvailable means the PoolManagerAvailable deployment is available, ie. at least the minimum available
+	// replicas required are up and running and in ready state.
+	PoolManagerAvailable CSPCConditionType = "PoolManagerAvailable"
+)
 
 // CStorPoolClusterCondition describes the state of a CSPC at a certain point.
 type CStorPoolClusterCondition struct {

--- a/pkg/internalapis/apis/cstor/cstorpoolcluster.go
+++ b/pkg/internalapis/apis/cstor/cstorpoolcluster.go
@@ -99,9 +99,9 @@ type PoolConfig struct {
 	// WriteCacheGroupType is the write cache raid type.
 	WriteCacheGroupType string `json:"writeCacheGroupType"`
 
-	// ThickProvisioning to enable thick provisioning
+	// ThickProvision to enable thick provisioning
 	// Optional -- defaults to false
-	ThickProvisioning bool `json:"thickProvisioning"`
+	ThickProvision bool `json:"thickProvision"`
 	// Compression to enable compression
 	// Optional -- defaults to off
 	// Possible values : lz, off
@@ -164,6 +164,13 @@ type CStorPoolClusterStatus struct {
 }
 
 type CSPCConditionType string
+
+// These are valid conditions of a cspc.
+const (
+	// PoolManagerAvailable means the PoolManagerAvailable deployment is available, ie. at least the minimum available
+	// replicas required are up and running and in ready state.
+	PoolManagerAvailable CSPCConditionType = "PoolManagerAvailable"
+)
 
 // CStorPoolClusterCondition describes the state of a CSPC at a certain point.
 type CStorPoolClusterCondition struct {

--- a/pkg/internalapis/apis/cstor/v1/zz_generated.conversion.go
+++ b/pkg/internalapis/apis/cstor/v1/zz_generated.conversion.go
@@ -1531,7 +1531,7 @@ func Convert_cstor_CVStatusResponse_To_v1_CVStatusResponse(in *cstor.CVStatusRes
 func autoConvert_v1_PoolConfig_To_cstor_PoolConfig(in *v1.PoolConfig, out *cstor.PoolConfig, s conversion.Scope) error {
 	out.DataRaidGroupType = in.DataRaidGroupType
 	out.WriteCacheGroupType = in.WriteCacheGroupType
-	out.ThickProvisioning = in.ThickProvisioning
+	out.ThickProvision = in.ThickProvision
 	out.Compression = in.Compression
 	out.Resources = (*corev1.ResourceRequirements)(unsafe.Pointer(in.Resources))
 	out.AuxResources = (*corev1.ResourceRequirements)(unsafe.Pointer(in.AuxResources))
@@ -1549,7 +1549,7 @@ func Convert_v1_PoolConfig_To_cstor_PoolConfig(in *v1.PoolConfig, out *cstor.Poo
 func autoConvert_cstor_PoolConfig_To_v1_PoolConfig(in *cstor.PoolConfig, out *v1.PoolConfig, s conversion.Scope) error {
 	out.DataRaidGroupType = in.DataRaidGroupType
 	out.WriteCacheGroupType = in.WriteCacheGroupType
-	out.ThickProvisioning = in.ThickProvisioning
+	out.ThickProvision = in.ThickProvision
 	out.Compression = in.Compression
 	out.Resources = (*corev1.ResourceRequirements)(unsafe.Pointer(in.Resources))
 	out.AuxResources = (*corev1.ResourceRequirements)(unsafe.Pointer(in.AuxResources))


### PR DESCRIPTION
This PR does following :

1. Changes 'ThickProvisioning' field to 'ThickProvision'.
Reason:  ThickProvisioning looks like an active thing going on and does not sound
                like a property key.

2. Add 'PoolManagerAvailable' condition type in cspc

Signed-off-by: Ashutosh Kumar <ashutosh.kumar@mayadata.io>