### PR TITLE
 fix(CSPI): update type of Capacity field in CStorPoolInstanceBlockdevice

### DIFF
--- a/design/cstor/v1/cstorpool.md
+++ b/design/cstor/v1/cstorpool.md
@@ -150,8 +150,8 @@ type CStorPoolInstanceBlockDevice struct {
 	BlockDeviceName string `json:"blockDeviceName"`
 
 	// Capacity is the capacity of the block device.
-	// It is system generated
-	Capacity string `json:"capacity"`
+	// It is system generated filled by CSPI controller
+	Capacity uint64 `json:"capacity"`
 
 	// DevLink is the dev link for block devices
 	DevLink string `json:"devLink"`

--- a/pkg/apis/cstor/v1/cstorpoolcluster.go
+++ b/pkg/apis/cstor/v1/cstorpoolcluster.go
@@ -143,7 +143,7 @@ type CStorPoolInstanceBlockDevice struct {
 	BlockDeviceName string `json:"blockDeviceName"`
 	// Capacity is the capacity of the block device.
 	// It is system generated
-	Capacity string `json:"capacity"`
+	Capacity uint64 `json:"capacity"`
 	// DevLink is the dev link for block devices
 	DevLink string `json:"devLink"`
 }

--- a/pkg/internalapis/apis/cstor/cstorpool_topology.go
+++ b/pkg/internalapis/apis/cstor/cstorpool_topology.go
@@ -127,6 +127,9 @@ type Vdev struct {
 	// 0 means partitioned disk, 1 means whole disk
 	IsWholeDisk int `json:"whole_disk,omitempty"`
 
+	// Capacity represents the size of the disk used in pool
+	Capacity uint64 `json:"asize,omitempty"`
+
 	// vdev indetailed statistics
 	VdevStats []uint64 `json:"vdev_stats,omitempty"`
 

--- a/pkg/internalapis/apis/cstor/cstorpoolcluster.go
+++ b/pkg/internalapis/apis/cstor/cstorpoolcluster.go
@@ -143,7 +143,7 @@ type CStorPoolInstanceBlockDevice struct {
 	BlockDeviceName string `json:"blockDeviceName"`
 	// Capacity is the capacity of the block device.
 	// It is system generated
-	Capacity string `json:"capacity"`
+	Capacity uint64 `json:"capacity"`
 	// DevLink is the dev link for block devices
 	DevLink string `json:"devLink"`
 }


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>
This PR updates the type of capacity field in CStorPoolInstanceBlockDevice from `string` to `uint64`.

**Why we need these changes**:
Since the capacity field in CStorPoolInstanceBlockdevice is used for the internal purpose being it as a `string` (or) `resource.Quantity` will lead to unnecessary conversions in the code due to this reason making it to `uint64` will make code as simple.

From 
```go
type CStorPoolInstanceBlockDevice struct {
	// BlockDeviceName is the name of the block device.
	BlockDeviceName string `json:"blockDeviceName"`
	// Capacity is the capacity of the block device.
	// It is system generated
	Capacity string `json:"capacity"`
	// It is system generated filled by CSPI controller
	Capacity string `json:"capacity"`
	// DevLink is the dev link for block devices
	DevLink string `json:"devLink"`
}
```
To
```go
type CStorPoolInstanceBlockDevice struct {
	// BlockDeviceName is the name of the block device.
	BlockDeviceName string `json:"blockDeviceName"`
	// Capacity is the capacity of the block device.
	// It is system generated
	Capacity string `json:"capacity"`
	// It is system generated filled by CSPI controller
	Capacity uint64 `json:"capacity"`
	// DevLink is the dev link for block devices
	DevLink string `json:"devLink"`
}
```