### PR TITLE
fix(SnapshotInfo): Remove Used field under CVRs SnapshotInfo

### DIFF
--- a/design/cstor/v1/cstorvolume.md
+++ b/design/cstor/v1/cstorvolume.md
@@ -330,7 +330,7 @@ type CStorSnapshotInfo struct {
 	LogicalReferenced uint64 `json:"logicalReferenced"`
 
 	// Used is the used bytes for given snapshot
-	Used uint64 `json:"used"`
+	// Used uint64 `json:"used"`
 }
 
 

--- a/pkg/apis/cstor/v1/cstorvolumereplica.go
+++ b/pkg/apis/cstor/v1/cstorvolumereplica.go
@@ -165,7 +165,7 @@ type CStorSnapshotInfo struct {
 	LogicalReferenced uint64 `json:"logicalReferenced"`
 
 	// Used is the used bytes for given snapshot
-	Used uint64 `json:"used"`
+	// Used uint64 `json:"used"`
 }
 
 // CStorVolumeReplicaCapacityDetails represents capacity information releated to volume

--- a/pkg/apis/cstor/v1/cstorvolumereplica.go
+++ b/pkg/apis/cstor/v1/cstorvolumereplica.go
@@ -164,6 +164,7 @@ type CStorSnapshotInfo struct {
 	// space consumed by metadata.
 	LogicalReferenced uint64 `json:"logicalReferenced"`
 
+	// TODO: We will revisit when we are working on rebuild estimates
 	// Used is the used bytes for given snapshot
 	// Used uint64 `json:"used"`
 }

--- a/pkg/internalapis/apis/cstor/cstorpool_topology.go
+++ b/pkg/internalapis/apis/cstor/cstorpool_topology.go
@@ -66,6 +66,9 @@ const (
 	PoolScanFuncStates
 )
 
+// NOTE: 1. VdevState represent the state of the vdev/disk in pool.
+//       2. VdevAux represents gives the reason why disk/vdev are in that state.
+
 // VdevState represent various device/disk states
 type VdevState uint64
 

--- a/pkg/internalapis/apis/cstor/cstorvolumereplica.go
+++ b/pkg/internalapis/apis/cstor/cstorvolumereplica.go
@@ -161,7 +161,7 @@ type CStorSnapshotInfo struct {
 	LogicalReferenced uint64 `json:"logicalReferenced"`
 
 	// Used is the used bytes for given snapshot
-	Used uint64 `json:"used"`
+	// Used uint64 `json:"used"`
 }
 
 // CStorVolumeCapacityDetails represents capacity information releated to volume

--- a/pkg/internalapis/apis/cstor/cstorvolumereplica.go
+++ b/pkg/internalapis/apis/cstor/cstorvolumereplica.go
@@ -160,6 +160,8 @@ type CStorSnapshotInfo struct {
 	// space consumed by metadata.
 	LogicalReferenced uint64 `json:"logicalReferenced"`
 
+	// TODO: We will revisit when we are working on rebuild estimates
+
 	// Used is the used bytes for given snapshot
 	// Used uint64 `json:"used"`
 }

--- a/pkg/internalapis/apis/cstor/v1/zz_generated.conversion.go
+++ b/pkg/internalapis/apis/cstor/v1/zz_generated.conversion.go
@@ -856,7 +856,6 @@ func Convert_cstor_CStorPoolInstanceStatus_To_v1_CStorPoolInstanceStatus(in *cst
 
 func autoConvert_v1_CStorSnapshotInfo_To_cstor_CStorSnapshotInfo(in *v1.CStorSnapshotInfo, out *cstor.CStorSnapshotInfo, s conversion.Scope) error {
 	out.LogicalReferenced = in.LogicalReferenced
-	out.Used = in.Used
 	return nil
 }
 
@@ -867,7 +866,6 @@ func Convert_v1_CStorSnapshotInfo_To_cstor_CStorSnapshotInfo(in *v1.CStorSnapsho
 
 func autoConvert_cstor_CStorSnapshotInfo_To_v1_CStorSnapshotInfo(in *cstor.CStorSnapshotInfo, out *v1.CStorSnapshotInfo, s conversion.Scope) error {
 	out.LogicalReferenced = in.LogicalReferenced
-	out.Used = in.Used
 	return nil
 }
 


### PR DESCRIPTION
This PR comments out the **Used** field in snapshotInfo under CVR.Status.Snapshots. 

**Why we need this PR**:
Since the Used filed under the snapshots needs to be updated periodically to show the data holding by particular snapshot(As Used can grow depends on overwrites). When we do periodic updates of the used field under snapshotInfo by fetching from **ZFS** then there will be an impact in IO performance to reduce the impact on IOs as of now removing the field. 