### PR TITLE
fix(base path): fix base path inside the containers

### DIFF
--- a/pkg/apis/types/types.go
+++ b/pkg/apis/types/types.go
@@ -81,7 +81,7 @@ const (
 )
 
 const (
-	CStorPoolBasePath = "/var/openebs/cstor-pool"
+	CStorPoolBasePath = "/var/openebs/cstor-pool/"
 	CacheFileName     = "pool.cache"
 )
 


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>
This PR updates the base path of OpenEBS from `/var/openebs/cstor-pool` to `/var/openebs/cstor-pool/`
**NOTE**:
This base path is used only inside the container to store files on Persistent Path.