### PR TITLE
feat(migrate): add migration related keys

### DIFF
--- a/pkg/apis/types/types.go
+++ b/pkg/apis/types/types.go
@@ -104,3 +104,12 @@ const (
 	//TotalWaitTime is the max time duration to wait for doing snapshot operation on all the replicas
 	TotalWaitTime = 60
 )
+
+const (
+	// OpenEBSDisableDependantsReconcileKey is the annotation key that decides to create
+	// children objects with OpenEBSDisableReconcileKey as true or false
+	OpenEBSDisableDependantsReconcileKey = "reconcile.openebs.io/disable-dependants"
+
+	// OldPoolName is the old pool that needs to be imported and renamed
+	OldPoolName = "cstorpoolinstance.openebs.io/oldname"
+)

--- a/pkg/apis/types/types.go
+++ b/pkg/apis/types/types.go
@@ -110,6 +110,7 @@ const (
 	// children objects with OpenEBSDisableReconcileKey as true or false
 	OpenEBSDisableDependantsReconcileKey = "reconcile.openebs.io/disable-dependants"
 
-	// OldPoolName is the old pool that needs to be imported and renamed
-	OldPoolName = "cstorpoolinstance.openebs.io/oldname"
+	// ExistingPoolName is the name of the pool already present on the disk
+	// that needs to be imported and renamed
+	ExistingPoolName = "import.cspi.cstor.openebs.io/existing-pool-name"
 )

--- a/pkg/apis/types/types.go
+++ b/pkg/apis/types/types.go
@@ -110,7 +110,7 @@ const (
 	// children objects with OpenEBSDisableReconcileKey as true or false
 	OpenEBSDisableDependantsReconcileKey = "reconcile.openebs.io/disable-dependants"
 
-	// ExistingPoolName is the name of the pool already present on the disk
-	// that needs to be imported and renamed
-	ExistingPoolName = "import.cspi.cstor.openebs.io/existing-pool-name"
+	// OpenEBSCStorExistingPoolName is the name of the cstor pool already present on 
+	// the disk that needs to be imported and renamed
+	OpenEBSCStorExistingPoolName = "import.cspi.cstor.openebs.io/existing-pool-name"
 )


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

This PR adds the keys used for migrating spc to csps. Refer the design doc: https://github.com/openebs/openebs/pull/2840