### PR TITLE
fix(volume-mgmt): handle mutual exclusion while updating istgt conf file

### DIFF
--- a/pkg/apis/types/types.go
+++ b/pkg/apis/types/types.go
@@ -113,7 +113,7 @@ const (
 	// children objects with OpenEBSDisableReconcileKey as true or false
 	OpenEBSDisableDependantsReconcileKey = "reconcile.openebs.io/disable-dependants"
 
-	// OpenEBSCStorExistingPoolName is the name of the cstor pool already present on 
+	// OpenEBSCStorExistingPoolName is the name of the cstor pool already present on
 	// the disk that needs to be imported and renamed
 	OpenEBSCStorExistingPoolName = "import.cspi.cstor.openebs.io/existing-pool-name"
 )


### PR DESCRIPTION
This PR updates the istgt.conf file only by taking `ConfFileMutex.Lock()` ConfFileMutex is present in  `github.com/openebs/api/pkg/apis/types`.  istgt.conf file is configuration file required to start istgt process(main process in cstor-istgt container).


Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>