### PR TITLE
feat(cspi status): add provisioned and healthy replica count in CSPI status

### DIFF
--- a/design/cstor/v1/cstorpool.md
+++ b/design/cstor/v1/cstorpool.md
@@ -243,6 +243,12 @@ type CStorPoolInstanceStatus struct {
 	Capacity CStorPoolInstanceCapacity `json:"capacity"`
 	//ReadOnly if pool is readOnly or not
 	ReadOnly bool `json:"readOnly"`
+	// ProvisionedReplicas describes the total count of Volume Replicas
+	// present in the cstor pool
+	ProvisionedReplicas int32 `json:"provisionedReplicas"`
+	// HealthyReplicas describes the total count of healthy Volume Replicas
+	// in the cstor pool
+	HealthyReplicas int32 `json:"healthyReplicas"`
 }
 
 // CStorPoolInstanceCapacity stores the pool capacity related attributes.

--- a/pkg/apis/cstor/v1/cstorpoolinstance.go
+++ b/pkg/apis/cstor/v1/cstorpoolinstance.go
@@ -106,6 +106,12 @@ type CStorPoolInstanceStatus struct {
 	Capacity CStorPoolInstanceCapacity `json:"capacity"`
 	//ReadOnly if pool is readOnly or not
 	ReadOnly bool `json:"readOnly"`
+	// ProvisionedReplicas describes the total count of Volume Replicas
+	// present in the cstor pool
+	ProvisionedReplicas int32 `json:"provisionedReplicas"`
+	// HealthyReplicas describes the total count of healthy Volume Replicas
+	// in the cstor pool
+	HealthyReplicas int32 `json:"healthyReplicas"`
 }
 
 // CStorPoolInstanceCapacity stores the pool capacity related attributes.

--- a/pkg/internalapis/apis/cstor/cstorpoolinstance.go
+++ b/pkg/internalapis/apis/cstor/cstorpoolinstance.go
@@ -106,6 +106,12 @@ type CStorPoolInstanceStatus struct {
 	Capacity CStorPoolInstanceCapacity `json:"capacity"`
 	//ReadOnly if pool is readOnly or not
 	ReadOnly bool `json:"readOnly"`
+	// ProvisionedReplicas describes the total count of Volume Replicas
+	// present in the cstor pool
+	ProvisionedReplicas int32 `json:"provisionedReplicas"`
+	// HealthyReplicas describes the total count of healthy Volume Replicas
+	// in the cstor pool
+	HealthyReplicas int32 `json:"healthyReplicas"`
 }
 
 // CStorPoolInstanceCapacity stores the pool capacity related attributes.

--- a/pkg/internalapis/apis/cstor/v1/zz_generated.conversion.go
+++ b/pkg/internalapis/apis/cstor/v1/zz_generated.conversion.go
@@ -847,6 +847,8 @@ func autoConvert_v1_CStorPoolInstanceStatus_To_cstor_CStorPoolInstanceStatus(in 
 		return err
 	}
 	out.ReadOnly = in.ReadOnly
+	out.ProvisionedReplicas = in.ProvisionedReplicas
+	out.HealthyReplicas = in.HealthyReplicas
 	return nil
 }
 
@@ -862,6 +864,8 @@ func autoConvert_cstor_CStorPoolInstanceStatus_To_v1_CStorPoolInstanceStatus(in 
 		return err
 	}
 	out.ReadOnly = in.ReadOnly
+	out.ProvisionedReplicas = in.ProvisionedReplicas
+	out.HealthyReplicas = in.HealthyReplicas
 	return nil
 }
 


### PR DESCRIPTION
This PR adds Provisioned and Healthy
replica count in CSPI status.

- When users execute `kubectl get cspi -n openebs` below will be output
```sh
 kubectl get cspi -n openebs
NAME                HOSTNAME    ALLOCATED   FREE     CAPACITY    READONLY   PROVISIONEDREPLICAS   HEALTHYREPLICAS   STATUS   AGE
cstor-stripe-fb4b   127.0.0.1   190k        19200M   19200190k   false      2                     1                 ONLINE   36m
```
**Provisioned Replicas**:  Count of volume replicas present in the pool.
**Healthy Replicas**: Count of Healthy volume replicas present in the pool.

It will be helpful to users to know how many replicas are healthy out of provisioned replicas
without executing `kubectl get cvr -n openebs -l cstorpoolinstance.openebs.io/name=<cspi_name>`

**Note to reviewers**:
- Fetching information of `Provisioned Replicas` from `zfs list` and `Healthy replicas` using `zfs stats`. 

Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>