### PR TITLE
refact(crds): refactor generate cstor crds based on openAPIV3 validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,9 @@ generate: generate-crds
 
 generate-crds: controller-gen
 	# Generate manifests e.g. CRD, RBAC etc.
-	$(CONTROLLER_GEN) crd paths="./pkg/apis/cstor" output:crd:artifacts:config=config/crds/bases
+	$(CONTROLLER_GEN) crd:trivialVersions=true,preserveUnknownFields=false paths="./pkg/apis/cstor/..." output:crd:artifacts:config=config/crds/bases
 	# merge all crds into a single file
+	rm $(ALL_CRDS)
 	cat config/crds/bases/*.yaml >> $(ALL_CRDS)
 
 .PHONY: kubegen

--- a/config/crds/all-crds.yaml
+++ b/config/crds/all-crds.yaml
@@ -298,7 +298,11 @@ spec:
                       required:
                       - blockDevices
                       type: object
+                    nullable: true
                     type: array
+                required:
+                - dataRaidGroups
+                - nodeSelector
                 type: object
               type: array
             priorityClassName:
@@ -771,7 +775,11 @@ spec:
                 required:
                 - blockDevices
                 type: object
+              nullable: true
               type: array
+          required:
+          - dataRaidGroups
+          - nodeSelector
           type: object
         status:
           description: Status is the possible statuses of the cstorpoolinstance resource.

--- a/config/crds/all-crds.yaml
+++ b/config/crds/all-crds.yaml
@@ -1,3 +1,4 @@
+
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -7,13 +8,34 @@ metadata:
   creationTimestamp: null
   name: cstorpoolclusters.cstor.openebs.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.healthyInstances
+    description: The number of healthy cStorPoolInstances
+    name: HealthyInstances
+    type: integer
+  - JSONPath: .status.provisionedInstances
+    description: The number of provisioned cStorPoolInstances
+    name: ProvisionedInstances
+    type: integer
+  - JSONPath: .status.desiredInstances
+    description: The number of desired cStorPoolInstances
+    name: DesiredInstances
+    type: integer
+  - JSONPath: .metadata.creationTimestamp
+    description: Age of CStorPoolCluster
+    name: Age
+    type: date
   group: cstor.openebs.io
   names:
     kind: CStorPoolCluster
     listKind: CStorPoolClusterList
     plural: cstorpoolclusters
+    shortNames:
+    - cspc
     singular: cstorpoolcluster
+  preserveUnknownFields: false
   scope: Namespaced
+  subresources: {}
   validation:
     openAPIV3Schema:
       description: CStorPoolCluster describes a CStorPoolCluster custom resource.
@@ -37,6 +59,7 @@ spec:
             auxResources:
               description: AuxResources are the compute resources required by the
                 cstor-pool pod side car containers.
+              nullable: true
               properties:
                 limits:
                   additionalProperties:
@@ -94,8 +117,6 @@ spec:
                                 type: string
                             required:
                             - blockDeviceName
-                            - capacity
-                            - devLink
                             type: object
                           type: array
                       required:
@@ -115,6 +136,7 @@ spec:
                       auxResources:
                         description: AuxResources are the compute resources required
                           by the cstor-pool pod side car containers.
+                        nullable: true
                         properties:
                           limits:
                             additionalProperties:
@@ -152,10 +174,12 @@ spec:
                           pool pod If left empty, DefaultPriorityClassName is applied.
                           (See CStorPoolClusterSpec.DefaultPriorityClassName) If both
                           are empty, not priority class is applied.
+                        nullable: true
                         type: string
                       resources:
                         description: Resources are the compute resources required
                           by the cstor-pool container.
+                        nullable: true
                         properties:
                           limits:
                             additionalProperties:
@@ -189,6 +213,7 @@ spec:
                           storage will be used by default it will be set to 85%. 2.
                           ROThresholdLimit value will be 0 <= ROThresholdLimit <=
                           100.'
+                        nullable: true
                         type: integer
                       thickProvision:
                         description: ThickProvision to enable thick provisioning Optional
@@ -235,20 +260,13 @@ spec:
                                 be empty, otherwise just a regular string.
                               type: string
                           type: object
+                        nullable: true
                         type: array
                       writeCacheGroupType:
                         description: WriteCacheGroupType is the write cache raid type.
                         type: string
                     required:
-                    - auxResources
-                    - compression
                     - dataRaidGroupType
-                    - priorityClassName
-                    - resources
-                    - roThresholdLimit
-                    - thickProvision
-                    - tolerations
-                    - writeCacheGroupType
                     type: object
                   writeCacheRaidGroups:
                     description: WriteCacheRaidGroups is the write cache raid group.
@@ -275,19 +293,12 @@ spec:
                                 type: string
                             required:
                             - blockDeviceName
-                            - capacity
-                            - devLink
                             type: object
                           type: array
                       required:
                       - blockDevices
                       type: object
                     type: array
-                required:
-                - dataRaidGroups
-                - nodeSelector
-                - poolConfig
-                - writeCacheRaidGroups
                 type: object
               type: array
             priorityClassName:
@@ -299,6 +310,7 @@ spec:
               description: DefaultResources are the compute resources required by
                 the cstor-pool container. If the resources at PoolConfig is not specified,
                 this is written to CSPI PoolConfig.
+              nullable: true
               properties:
                 limits:
                   additionalProperties:
@@ -363,13 +375,8 @@ spec:
                       just a regular string.
                     type: string
                 type: object
+              nullable: true
               type: array
-          required:
-          - auxResources
-          - pools
-          - priorityClassName
-          - resources
-          - tolerations
           type: object
         status:
           description: CStorPoolClusterStatus represents the latest available observations
@@ -407,26 +414,25 @@ spec:
                 - status
                 - type
                 type: object
+              nullable: true
               type: array
             desiredInstances:
               description: DesiredInstances is the number of CSPI(s) that should be
                 provisioned.
               format: int32
+              nullable: true
               type: integer
             healthyInstances:
               description: HealthyInstances is the number of CSPI(s) that are healthy.
               format: int32
+              nullable: true
               type: integer
             provisionedInstances:
               description: ProvisionedInstances is the the number of CSPI present
                 at the current state.
               format: int32
+              nullable: true
               type: integer
-          required:
-          - conditions
-          - desiredInstances
-          - healthyInstances
-          - provisionedInstances
           type: object
         versionDetails:
           description: VersionDetails provides the details for upgrade
@@ -453,6 +459,7 @@ spec:
                 lastUpdateTime:
                   description: LastUpdateTime is the time the status was last  updated
                   format: date-time
+                  nullable: true
                   type: string
                 message:
                   description: Message is a human readable message if some error occurs
@@ -463,20 +470,10 @@ spec:
                 state:
                   description: State is the state of reconciliation
                   type: string
-              required:
-              - current
-              - dependentsUpgraded
-              - state
               type: object
-          required:
-          - autoUpgrade
-          - desired
-          - status
           type: object
       required:
       - spec
-      - status
-      - versionDetails
       type: object
   version: v1
   versions:
@@ -499,13 +496,59 @@ metadata:
   creationTimestamp: null
   name: cstorpoolinstances.cstor.openebs.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.hostName
+    description: Host name where cstorpool instances scheduled
+    name: HostName
+    type: string
+  - JSONPath: .status.capacity.used
+    description: The amount of storage space within the pool that has been physically
+      allocated
+    name: Allocated
+    type: string
+  - JSONPath: .status.capacity.free
+    description: The amount of usable free space available in the pool
+    name: Free
+    type: string
+  - JSONPath: .status.capacity.total
+    description: Total amount of usable space in pool
+    name: Capacity
+    type: string
+  - JSONPath: .status.readOnly
+    description: Identifies the pool read only mode
+    name: ReadOnly
+    type: boolean
+  - JSONPath: .status.provisionedReplicas
+    description: Represents no.of replicas present in the pool
+    name: ProvisionedReplicas
+    type: integer
+  - JSONPath: .status.healthyReplicas
+    description: Represents no.of healthy replicas present in the pool
+    name: HealthyReplicas
+    type: integer
+  - JSONPath: .spec.poolConfig.dataRaidGroupType
+    description: Represents the type of the storage pool
+    name: Type
+    type: string
+  - JSONPath: .status.phase
+    description: Identifies the current health of the pool
+    name: Status
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: Age of CStorPoolInstance
+    name: Age
+    type: date
   group: cstor.openebs.io
   names:
     kind: CStorPoolInstance
     listKind: CStorPoolInstanceList
     plural: cstorpoolinstances
+    shortNames:
+    - cspi
     singular: cstorpoolinstance
+  preserveUnknownFields: false
   scope: Namespaced
+  subresources: {}
   validation:
     openAPIV3Schema:
       description: CStorPoolInstance describes a cstor pool instance resource.
@@ -550,8 +593,6 @@ spec:
                           type: string
                       required:
                       - blockDeviceName
-                      - capacity
-                      - devLink
                       type: object
                     type: array
                 required:
@@ -575,6 +616,7 @@ spec:
                 auxResources:
                   description: AuxResources are the compute resources required by
                     the cstor-pool pod side car containers.
+                  nullable: true
                   properties:
                     limits:
                       additionalProperties:
@@ -610,10 +652,12 @@ spec:
                   description: PriorityClassName if specified applies to this pool
                     pod If left empty, DefaultPriorityClassName is applied. (See CStorPoolClusterSpec.DefaultPriorityClassName)
                     If both are empty, not priority class is applied.
+                  nullable: true
                   type: string
                 resources:
                   description: Resources are the compute resources required by the
                     cstor-pool container.
+                  nullable: true
                   properties:
                     limits:
                       additionalProperties:
@@ -645,6 +689,7 @@ spec:
                     ROThresholdLimit is set to 100 then entire    pool storage will
                     be used by default it will be set to 85%. 2. ROThresholdLimit
                     value will be 0 <= ROThresholdLimit <= 100.'
+                  nullable: true
                   type: integer
                 thickProvision:
                   description: ThickProvision to enable thick provisioning Optional
@@ -689,20 +734,13 @@ spec:
                           otherwise just a regular string.
                         type: string
                     type: object
+                  nullable: true
                   type: array
                 writeCacheGroupType:
                   description: WriteCacheGroupType is the write cache raid type.
                   type: string
               required:
-              - auxResources
-              - compression
               - dataRaidGroupType
-              - priorityClassName
-              - resources
-              - roThresholdLimit
-              - thickProvision
-              - tolerations
-              - writeCacheGroupType
               type: object
             writeCacheRaidGroups:
               description: WriteCacheRaidGroups is the write cache raid group.
@@ -728,20 +766,12 @@ spec:
                           type: string
                       required:
                       - blockDeviceName
-                      - capacity
-                      - devLink
                       type: object
                     type: array
                 required:
                 - blockDevices
                 type: object
               type: array
-          required:
-          - dataRaidGroups
-          - hostName
-          - nodeSelector
-          - poolConfig
-          - writeCacheRaidGroups
           type: object
         status:
           description: Status is the possible statuses of the cstorpoolinstance resource.
@@ -753,29 +783,48 @@ spec:
                   anyOf:
                   - type: integer
                   - type: string
-                  description: Unsed capacity in the pool
+                  description: Amount of usable space in the pool after excluding
+                    metadata and raid parity
                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                   x-kubernetes-int-or-string: true
                 total:
                   anyOf:
                   - type: integer
                   - type: string
-                  description: Total capacity of the pool, equal to the sum of the
-                    all data raidgroups
+                  description: Sum of usable capacity in all the data raidgroups
                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                   x-kubernetes-int-or-string: true
                 used:
                   anyOf:
                   - type: integer
                   - type: string
-                  description: The amount of capacity allocated to all datasets and
-                    internal metadata
+                  description: Amount of physical data (and its metadata) written
+                    to pool after applying compression, etc..,
                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                   x-kubernetes-int-or-string: true
+                zfs:
+                  description: ZFSCapacityAttributes contains advanced information
+                    about pool capacity details
+                  properties:
+                    logicalUsed:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: LogicalUsed is the amount of space that is "logically"
+                        consumed by this pool and all its descendents. The logical
+                        space ignores the effect of the compression and copies properties,
+                        giving a quantity closer to the amount of data that applications
+                        see. However, it does include space consumed by metadata.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  required:
+                  - logicalUsed
+                  type: object
               required:
               - free
               - total
               - used
+              - zfs
               type: object
             conditions:
               description: Current state of CSPI with details.
@@ -810,17 +859,23 @@ spec:
                 - type
                 type: object
               type: array
+            healthyReplicas:
+              description: HealthyReplicas describes the total count of healthy Volume
+                Replicas in the cstor pool
+              format: int32
+              type: integer
             phase:
               description: ' The phase of a CStorPool is a simple, high-level summary
                 of the pool state on the  node.'
               type: string
+            provisionedReplicas:
+              description: ProvisionedReplicas describes the total count of Volume
+                Replicas present in the cstor pool
+              format: int32
+              type: integer
             readOnly:
               description: ReadOnly if pool is readOnly or not
               type: boolean
-          required:
-          - capacity
-          - phase
-          - readOnly
           type: object
         versionDetails:
           description: VersionDetails is the openebs version.
@@ -847,6 +902,7 @@ spec:
                 lastUpdateTime:
                   description: LastUpdateTime is the time the status was last  updated
                   format: date-time
+                  nullable: true
                   type: string
                 message:
                   description: Message is a human readable message if some error occurs
@@ -857,20 +913,10 @@ spec:
                 state:
                   description: State is the state of reconciliation
                   type: string
-              required:
-              - current
-              - dependentsUpgraded
-              - state
               type: object
-          required:
-          - autoUpgrade
-          - desired
-          - status
           type: object
       required:
       - spec
-      - status
-      - versionDetails
       type: object
   version: v1
   versions:
@@ -893,13 +939,30 @@ metadata:
   creationTimestamp: null
   name: cstorvolumeconfigs.cstor.openebs.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.capacity.storage
+    description: Identifies the volume capacity
+    name: Capacity
+    type: string
+  - JSONPath: .status.phase
+    description: Identifies the volume provisioning status
+    name: Status
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: Age of CStorVolumeReplica
+    name: Age
+    type: date
   group: cstor.openebs.io
   names:
     kind: CStorVolumeConfig
     listKind: CStorVolumeConfigList
     plural: cstorvolumeconfigs
+    shortNames:
+    - cvc
     singular: cstorvolumeconfig
+  preserveUnknownFields: false
   scope: Namespaced
+  subresources: {}
   validation:
     openAPIV3Schema:
       description: CStorVolumeConfig describes a cstor volume config resource created
@@ -1005,7 +1068,6 @@ spec:
                         based on the given topology
                       type: boolean
                   required:
-                  - blockSize
                   - replicaAffinity
                   type: object
                 replica:
@@ -1363,11 +1425,6 @@ spec:
                         type: object
                       type: array
                   type: object
-              required:
-              - provision
-              - replica
-              - replicaPoolInfo
-              - target
               type: object
             provision:
               description: Provision represents the initial volume configuration for
@@ -1454,9 +1511,6 @@ spec:
               items:
                 type: string
               type: array
-          required:
-          - phase
-          - poolInfo
           type: object
         versionDetails:
           description: VersionDetails provides the details for upgrade
@@ -1483,6 +1537,7 @@ spec:
                 lastUpdateTime:
                   description: LastUpdateTime is the time the status was last  updated
                   format: date-time
+                  nullable: true
                   type: string
                 message:
                   description: Message is a human readable message if some error occurs
@@ -1493,15 +1548,7 @@ spec:
                 state:
                   description: State is the state of reconciliation
                   type: string
-              required:
-              - current
-              - dependentsUpgraded
-              - state
               type: object
-          required:
-          - autoUpgrade
-          - desired
-          - status
           type: object
       required:
       - spec
@@ -1534,7 +1581,10 @@ spec:
     kind: CStorVolumePolicy
     listKind: CStorVolumePolicyList
     plural: cstorvolumepolicies
+    shortNames:
+    - cvp
     singular: cstorvolumepolicy
+  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:
@@ -1576,7 +1626,6 @@ spec:
                     based on the given topology
                   type: boolean
               required:
-              - blockSize
               - replicaAffinity
               type: object
             replica:
@@ -1917,23 +1966,15 @@ spec:
                     type: object
                   type: array
               type: object
-          required:
-          - provision
-          - replica
-          - replicaPoolInfo
-          - target
           type: object
         status:
           description: CStorVolumePolicyStatus is for handling status of CstorVolumePolicy
           properties:
             phase:
               type: string
-          required:
-          - phase
           type: object
       required:
       - spec
-      - status
       type: object
   version: v1
   versions:
@@ -1956,13 +1997,34 @@ metadata:
   creationTimestamp: null
   name: cstorvolumereplicas.cstor.openebs.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.capacity.total
+    description: The amount of disk space consumed by a dataset and all its descendents
+    name: Allocated
+    type: string
+  - JSONPath: .status.capacity.used
+    description: The amount of space that is logically consumed by this dataset
+    name: Used
+    type: string
+  - JSONPath: .status.phase
+    description: Identifies the current state of the replicas
+    name: Status
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: Age of CStorVolumeReplica
+    name: Age
+    type: date
   group: cstor.openebs.io
   names:
     kind: CStorVolumeReplica
     listKind: CStorVolumeReplicaList
     plural: cstorvolumereplicas
+    shortNames:
+    - cvr
     singular: cstorvolumereplica
+  preserveUnknownFields: false
   scope: Namespaced
+  subresources: {}
   validation:
     openAPIV3Schema:
       description: CStorVolumeReplica describes a cstor volume resource created as
@@ -2011,13 +2073,6 @@ spec:
               description: ZvolWorkers represents number of threads that executes
                 client IOs
               type: string
-          required:
-          - blockSize
-          - capacity
-          - compression
-          - replicaid
-          - targetIP
-          - zvolWorkers
           type: object
         status:
           description: CStorVolumeReplicaStatus is for handling status of cvr.
@@ -2044,10 +2099,12 @@ spec:
             lastTransitionTime:
               description: LastTransitionTime refers to the time when the phase changes
               format: date-time
+              nullable: true
               type: string
             lastUpdateTime:
               description: The last updated time
               format: date-time
+              nullable: true
               type: string
             message:
               description: A human readable message indicating details about the transition.
@@ -2065,13 +2122,8 @@ spec:
                       see. It also includes space consumed by metadata.
                     format: int64
                     type: integer
-                  used:
-                    description: Used is the used bytes for given snapshot
-                    format: int64
-                    type: integer
                 required:
                 - logicalReferenced
-                - used
                 type: object
               description: PendingSnapshots contains list of pending snapshots that
                 are not yet available on this replica
@@ -2093,20 +2145,12 @@ spec:
                       see. It also includes space consumed by metadata.
                     format: int64
                     type: integer
-                  used:
-                    description: Used is the used bytes for given snapshot
-                    format: int64
-                    type: integer
                 required:
                 - logicalReferenced
-                - used
                 type: object
               description: Snapshots contains list of snapshots, and their properties,
                 created on CVR
               type: object
-          required:
-          - capacity
-          - phase
           type: object
         versionDetails:
           description: VersionDetails provides the details for upgrade
@@ -2133,6 +2177,7 @@ spec:
                 lastUpdateTime:
                   description: LastUpdateTime is the time the status was last  updated
                   format: date-time
+                  nullable: true
                   type: string
                 message:
                   description: Message is a human readable message if some error occurs
@@ -2143,20 +2188,10 @@ spec:
                 state:
                   description: State is the state of reconciliation
                   type: string
-              required:
-              - current
-              - dependentsUpgraded
-              - state
               type: object
-          required:
-          - autoUpgrade
-          - desired
-          - status
           type: object
       required:
       - spec
-      - status
-      - versionDetails
       type: object
   version: v1
   versions:
@@ -2179,13 +2214,30 @@ metadata:
   creationTimestamp: null
   name: cstorvolumes.cstor.openebs.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.capacity
+    description: Current volume capacity
+    name: Capacity
+    type: string
+  - JSONPath: .status.phase
+    description: Identifies the current health of the volume
+    name: Status
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: Age of CStorVolume
+    name: Age
+    type: date
   group: cstor.openebs.io
   names:
     kind: CStorVolume
     listKind: CStorVolumeList
     plural: cstorvolumes
+    shortNames:
+    - cv
     singular: cstorvolume
+  preserveUnknownFields: false
   scope: Namespaced
+  subresources: {}
   validation:
     openAPIV3Schema:
       description: CStorVolume describes a cstor volume resource created as custom
@@ -2250,15 +2302,6 @@ spec:
               description: iSCSI Target Portal. The Portal is combination of IP:port
                 (typically TCP ports 3260)
               type: string
-          required:
-          - capacity
-          - consistencyFactor
-          - desiredReplicationFactor
-          - iqn
-          - replicationFactor
-          - targetIP
-          - targetPort
-          - targetPortal
           type: object
         status:
           description: CStorVolumeStatus is for handling status of cvr.
@@ -2311,11 +2354,13 @@ spec:
             lastTransitionTime:
               description: LastTransitionTime refers to the time when the phase changes
               format: date-time
+              nullable: true
               type: string
             lastUpdateTime:
               description: LastUpdateTime refers to the time when last status updated
                 due to any operations
               format: date-time
+              nullable: true
               type: string
             message:
               description: A human-readable message indicating details about why the
@@ -2377,8 +2422,6 @@ spec:
                 - upTime
                 type: object
               type: array
-          required:
-          - phase
           type: object
         versionDetails:
           description: VersionDetails provides the details for upgrade
@@ -2405,6 +2448,7 @@ spec:
                 lastUpdateTime:
                   description: LastUpdateTime is the time the status was last  updated
                   format: date-time
+                  nullable: true
                   type: string
                 message:
                   description: Message is a human readable message if some error occurs
@@ -2415,20 +2459,10 @@ spec:
                 state:
                   description: State is the state of reconciliation
                   type: string
-              required:
-              - current
-              - dependentsUpgraded
-              - state
               type: object
-          required:
-          - autoUpgrade
-          - desired
-          - status
           type: object
       required:
       - spec
-      - status
-      - versionDetails
       type: object
   version: v1
   versions:

--- a/config/crds/bases/cstor.openebs.io_cstorpoolclusters.yaml
+++ b/config/crds/bases/cstor.openebs.io_cstorpoolclusters.yaml
@@ -8,13 +8,34 @@ metadata:
   creationTimestamp: null
   name: cstorpoolclusters.cstor.openebs.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.healthyInstances
+    description: The number of healthy cStorPoolInstances
+    name: HealthyInstances
+    type: integer
+  - JSONPath: .status.provisionedInstances
+    description: The number of provisioned cStorPoolInstances
+    name: ProvisionedInstances
+    type: integer
+  - JSONPath: .status.desiredInstances
+    description: The number of desired cStorPoolInstances
+    name: DesiredInstances
+    type: integer
+  - JSONPath: .metadata.creationTimestamp
+    description: Age of CStorPoolCluster
+    name: Age
+    type: date
   group: cstor.openebs.io
   names:
     kind: CStorPoolCluster
     listKind: CStorPoolClusterList
     plural: cstorpoolclusters
+    shortNames:
+    - cspc
     singular: cstorpoolcluster
+  preserveUnknownFields: false
   scope: Namespaced
+  subresources: {}
   validation:
     openAPIV3Schema:
       description: CStorPoolCluster describes a CStorPoolCluster custom resource.
@@ -38,6 +59,7 @@ spec:
             auxResources:
               description: AuxResources are the compute resources required by the
                 cstor-pool pod side car containers.
+              nullable: true
               properties:
                 limits:
                   additionalProperties:
@@ -95,8 +117,6 @@ spec:
                                 type: string
                             required:
                             - blockDeviceName
-                            - capacity
-                            - devLink
                             type: object
                           type: array
                       required:
@@ -116,6 +136,7 @@ spec:
                       auxResources:
                         description: AuxResources are the compute resources required
                           by the cstor-pool pod side car containers.
+                        nullable: true
                         properties:
                           limits:
                             additionalProperties:
@@ -153,10 +174,12 @@ spec:
                           pool pod If left empty, DefaultPriorityClassName is applied.
                           (See CStorPoolClusterSpec.DefaultPriorityClassName) If both
                           are empty, not priority class is applied.
+                        nullable: true
                         type: string
                       resources:
                         description: Resources are the compute resources required
                           by the cstor-pool container.
+                        nullable: true
                         properties:
                           limits:
                             additionalProperties:
@@ -190,6 +213,7 @@ spec:
                           storage will be used by default it will be set to 85%. 2.
                           ROThresholdLimit value will be 0 <= ROThresholdLimit <=
                           100.'
+                        nullable: true
                         type: integer
                       thickProvision:
                         description: ThickProvision to enable thick provisioning Optional
@@ -236,20 +260,13 @@ spec:
                                 be empty, otherwise just a regular string.
                               type: string
                           type: object
+                        nullable: true
                         type: array
                       writeCacheGroupType:
                         description: WriteCacheGroupType is the write cache raid type.
                         type: string
                     required:
-                    - auxResources
-                    - compression
                     - dataRaidGroupType
-                    - priorityClassName
-                    - resources
-                    - roThresholdLimit
-                    - thickProvision
-                    - tolerations
-                    - writeCacheGroupType
                     type: object
                   writeCacheRaidGroups:
                     description: WriteCacheRaidGroups is the write cache raid group.
@@ -276,19 +293,12 @@ spec:
                                 type: string
                             required:
                             - blockDeviceName
-                            - capacity
-                            - devLink
                             type: object
                           type: array
                       required:
                       - blockDevices
                       type: object
                     type: array
-                required:
-                - dataRaidGroups
-                - nodeSelector
-                - poolConfig
-                - writeCacheRaidGroups
                 type: object
               type: array
             priorityClassName:
@@ -300,6 +310,7 @@ spec:
               description: DefaultResources are the compute resources required by
                 the cstor-pool container. If the resources at PoolConfig is not specified,
                 this is written to CSPI PoolConfig.
+              nullable: true
               properties:
                 limits:
                   additionalProperties:
@@ -364,13 +375,8 @@ spec:
                       just a regular string.
                     type: string
                 type: object
+              nullable: true
               type: array
-          required:
-          - auxResources
-          - pools
-          - priorityClassName
-          - resources
-          - tolerations
           type: object
         status:
           description: CStorPoolClusterStatus represents the latest available observations
@@ -408,26 +414,25 @@ spec:
                 - status
                 - type
                 type: object
+              nullable: true
               type: array
             desiredInstances:
               description: DesiredInstances is the number of CSPI(s) that should be
                 provisioned.
               format: int32
+              nullable: true
               type: integer
             healthyInstances:
               description: HealthyInstances is the number of CSPI(s) that are healthy.
               format: int32
+              nullable: true
               type: integer
             provisionedInstances:
               description: ProvisionedInstances is the the number of CSPI present
                 at the current state.
               format: int32
+              nullable: true
               type: integer
-          required:
-          - conditions
-          - desiredInstances
-          - healthyInstances
-          - provisionedInstances
           type: object
         versionDetails:
           description: VersionDetails provides the details for upgrade
@@ -454,6 +459,7 @@ spec:
                 lastUpdateTime:
                   description: LastUpdateTime is the time the status was last  updated
                   format: date-time
+                  nullable: true
                   type: string
                 message:
                   description: Message is a human readable message if some error occurs
@@ -464,20 +470,10 @@ spec:
                 state:
                   description: State is the state of reconciliation
                   type: string
-              required:
-              - current
-              - dependentsUpgraded
-              - state
               type: object
-          required:
-          - autoUpgrade
-          - desired
-          - status
           type: object
       required:
       - spec
-      - status
-      - versionDetails
       type: object
   version: v1
   versions:

--- a/config/crds/bases/cstor.openebs.io_cstorpoolclusters.yaml
+++ b/config/crds/bases/cstor.openebs.io_cstorpoolclusters.yaml
@@ -298,7 +298,11 @@ spec:
                       required:
                       - blockDevices
                       type: object
+                    nullable: true
                     type: array
+                required:
+                - dataRaidGroups
+                - nodeSelector
                 type: object
               type: array
             priorityClassName:

--- a/config/crds/bases/cstor.openebs.io_cstorpoolinstances.yaml
+++ b/config/crds/bases/cstor.openebs.io_cstorpoolinstances.yaml
@@ -283,7 +283,11 @@ spec:
                 required:
                 - blockDevices
                 type: object
+              nullable: true
               type: array
+          required:
+          - dataRaidGroups
+          - nodeSelector
           type: object
         status:
           description: Status is the possible statuses of the cstorpoolinstance resource.

--- a/config/crds/bases/cstor.openebs.io_cstorpoolinstances.yaml
+++ b/config/crds/bases/cstor.openebs.io_cstorpoolinstances.yaml
@@ -8,13 +8,59 @@ metadata:
   creationTimestamp: null
   name: cstorpoolinstances.cstor.openebs.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.hostName
+    description: Host name where cstorpool instances scheduled
+    name: HostName
+    type: string
+  - JSONPath: .status.capacity.used
+    description: The amount of storage space within the pool that has been physically
+      allocated
+    name: Allocated
+    type: string
+  - JSONPath: .status.capacity.free
+    description: The amount of usable free space available in the pool
+    name: Free
+    type: string
+  - JSONPath: .status.capacity.total
+    description: Total amount of usable space in pool
+    name: Capacity
+    type: string
+  - JSONPath: .status.readOnly
+    description: Identifies the pool read only mode
+    name: ReadOnly
+    type: boolean
+  - JSONPath: .status.provisionedReplicas
+    description: Represents no.of replicas present in the pool
+    name: ProvisionedReplicas
+    type: integer
+  - JSONPath: .status.healthyReplicas
+    description: Represents no.of healthy replicas present in the pool
+    name: HealthyReplicas
+    type: integer
+  - JSONPath: .spec.poolConfig.dataRaidGroupType
+    description: Represents the type of the storage pool
+    name: Type
+    type: string
+  - JSONPath: .status.phase
+    description: Identifies the current health of the pool
+    name: Status
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: Age of CStorPoolInstance
+    name: Age
+    type: date
   group: cstor.openebs.io
   names:
     kind: CStorPoolInstance
     listKind: CStorPoolInstanceList
     plural: cstorpoolinstances
+    shortNames:
+    - cspi
     singular: cstorpoolinstance
+  preserveUnknownFields: false
   scope: Namespaced
+  subresources: {}
   validation:
     openAPIV3Schema:
       description: CStorPoolInstance describes a cstor pool instance resource.
@@ -59,8 +105,6 @@ spec:
                           type: string
                       required:
                       - blockDeviceName
-                      - capacity
-                      - devLink
                       type: object
                     type: array
                 required:
@@ -84,6 +128,7 @@ spec:
                 auxResources:
                   description: AuxResources are the compute resources required by
                     the cstor-pool pod side car containers.
+                  nullable: true
                   properties:
                     limits:
                       additionalProperties:
@@ -119,10 +164,12 @@ spec:
                   description: PriorityClassName if specified applies to this pool
                     pod If left empty, DefaultPriorityClassName is applied. (See CStorPoolClusterSpec.DefaultPriorityClassName)
                     If both are empty, not priority class is applied.
+                  nullable: true
                   type: string
                 resources:
                   description: Resources are the compute resources required by the
                     cstor-pool container.
+                  nullable: true
                   properties:
                     limits:
                       additionalProperties:
@@ -154,6 +201,7 @@ spec:
                     ROThresholdLimit is set to 100 then entire    pool storage will
                     be used by default it will be set to 85%. 2. ROThresholdLimit
                     value will be 0 <= ROThresholdLimit <= 100.'
+                  nullable: true
                   type: integer
                 thickProvision:
                   description: ThickProvision to enable thick provisioning Optional
@@ -198,20 +246,13 @@ spec:
                           otherwise just a regular string.
                         type: string
                     type: object
+                  nullable: true
                   type: array
                 writeCacheGroupType:
                   description: WriteCacheGroupType is the write cache raid type.
                   type: string
               required:
-              - auxResources
-              - compression
               - dataRaidGroupType
-              - priorityClassName
-              - resources
-              - roThresholdLimit
-              - thickProvision
-              - tolerations
-              - writeCacheGroupType
               type: object
             writeCacheRaidGroups:
               description: WriteCacheRaidGroups is the write cache raid group.
@@ -237,20 +278,12 @@ spec:
                           type: string
                       required:
                       - blockDeviceName
-                      - capacity
-                      - devLink
                       type: object
                     type: array
                 required:
                 - blockDevices
                 type: object
               type: array
-          required:
-          - dataRaidGroups
-          - hostName
-          - nodeSelector
-          - poolConfig
-          - writeCacheRaidGroups
           type: object
         status:
           description: Status is the possible statuses of the cstorpoolinstance resource.
@@ -262,29 +295,48 @@ spec:
                   anyOf:
                   - type: integer
                   - type: string
-                  description: Unsed capacity in the pool
+                  description: Amount of usable space in the pool after excluding
+                    metadata and raid parity
                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                   x-kubernetes-int-or-string: true
                 total:
                   anyOf:
                   - type: integer
                   - type: string
-                  description: Total capacity of the pool, equal to the sum of the
-                    all data raidgroups
+                  description: Sum of usable capacity in all the data raidgroups
                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                   x-kubernetes-int-or-string: true
                 used:
                   anyOf:
                   - type: integer
                   - type: string
-                  description: The amount of capacity allocated to all datasets and
-                    internal metadata
+                  description: Amount of physical data (and its metadata) written
+                    to pool after applying compression, etc..,
                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                   x-kubernetes-int-or-string: true
+                zfs:
+                  description: ZFSCapacityAttributes contains advanced information
+                    about pool capacity details
+                  properties:
+                    logicalUsed:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: LogicalUsed is the amount of space that is "logically"
+                        consumed by this pool and all its descendents. The logical
+                        space ignores the effect of the compression and copies properties,
+                        giving a quantity closer to the amount of data that applications
+                        see. However, it does include space consumed by metadata.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  required:
+                  - logicalUsed
+                  type: object
               required:
               - free
               - total
               - used
+              - zfs
               type: object
             conditions:
               description: Current state of CSPI with details.
@@ -319,17 +371,23 @@ spec:
                 - type
                 type: object
               type: array
+            healthyReplicas:
+              description: HealthyReplicas describes the total count of healthy Volume
+                Replicas in the cstor pool
+              format: int32
+              type: integer
             phase:
               description: ' The phase of a CStorPool is a simple, high-level summary
                 of the pool state on the  node.'
               type: string
+            provisionedReplicas:
+              description: ProvisionedReplicas describes the total count of Volume
+                Replicas present in the cstor pool
+              format: int32
+              type: integer
             readOnly:
               description: ReadOnly if pool is readOnly or not
               type: boolean
-          required:
-          - capacity
-          - phase
-          - readOnly
           type: object
         versionDetails:
           description: VersionDetails is the openebs version.
@@ -356,6 +414,7 @@ spec:
                 lastUpdateTime:
                   description: LastUpdateTime is the time the status was last  updated
                   format: date-time
+                  nullable: true
                   type: string
                 message:
                   description: Message is a human readable message if some error occurs
@@ -366,20 +425,10 @@ spec:
                 state:
                   description: State is the state of reconciliation
                   type: string
-              required:
-              - current
-              - dependentsUpgraded
-              - state
               type: object
-          required:
-          - autoUpgrade
-          - desired
-          - status
           type: object
       required:
       - spec
-      - status
-      - versionDetails
       type: object
   version: v1
   versions:

--- a/config/crds/bases/cstor.openebs.io_cstorvolumeconfigs.yaml
+++ b/config/crds/bases/cstor.openebs.io_cstorvolumeconfigs.yaml
@@ -8,13 +8,30 @@ metadata:
   creationTimestamp: null
   name: cstorvolumeconfigs.cstor.openebs.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.capacity.storage
+    description: Identifies the volume capacity
+    name: Capacity
+    type: string
+  - JSONPath: .status.phase
+    description: Identifies the volume provisioning status
+    name: Status
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: Age of CStorVolumeReplica
+    name: Age
+    type: date
   group: cstor.openebs.io
   names:
     kind: CStorVolumeConfig
     listKind: CStorVolumeConfigList
     plural: cstorvolumeconfigs
+    shortNames:
+    - cvc
     singular: cstorvolumeconfig
+  preserveUnknownFields: false
   scope: Namespaced
+  subresources: {}
   validation:
     openAPIV3Schema:
       description: CStorVolumeConfig describes a cstor volume config resource created
@@ -120,7 +137,6 @@ spec:
                         based on the given topology
                       type: boolean
                   required:
-                  - blockSize
                   - replicaAffinity
                   type: object
                 replica:
@@ -478,11 +494,6 @@ spec:
                         type: object
                       type: array
                   type: object
-              required:
-              - provision
-              - replica
-              - replicaPoolInfo
-              - target
               type: object
             provision:
               description: Provision represents the initial volume configuration for
@@ -569,9 +580,6 @@ spec:
               items:
                 type: string
               type: array
-          required:
-          - phase
-          - poolInfo
           type: object
         versionDetails:
           description: VersionDetails provides the details for upgrade
@@ -598,6 +606,7 @@ spec:
                 lastUpdateTime:
                   description: LastUpdateTime is the time the status was last  updated
                   format: date-time
+                  nullable: true
                   type: string
                 message:
                   description: Message is a human readable message if some error occurs
@@ -608,15 +617,7 @@ spec:
                 state:
                   description: State is the state of reconciliation
                   type: string
-              required:
-              - current
-              - dependentsUpgraded
-              - state
               type: object
-          required:
-          - autoUpgrade
-          - desired
-          - status
           type: object
       required:
       - spec

--- a/config/crds/bases/cstor.openebs.io_cstorvolumepolicies.yaml
+++ b/config/crds/bases/cstor.openebs.io_cstorvolumepolicies.yaml
@@ -13,7 +13,10 @@ spec:
     kind: CStorVolumePolicy
     listKind: CStorVolumePolicyList
     plural: cstorvolumepolicies
+    shortNames:
+    - cvp
     singular: cstorvolumepolicy
+  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:
@@ -55,7 +58,6 @@ spec:
                     based on the given topology
                   type: boolean
               required:
-              - blockSize
               - replicaAffinity
               type: object
             replica:
@@ -396,23 +398,15 @@ spec:
                     type: object
                   type: array
               type: object
-          required:
-          - provision
-          - replica
-          - replicaPoolInfo
-          - target
           type: object
         status:
           description: CStorVolumePolicyStatus is for handling status of CstorVolumePolicy
           properties:
             phase:
               type: string
-          required:
-          - phase
           type: object
       required:
       - spec
-      - status
       type: object
   version: v1
   versions:

--- a/config/crds/bases/cstor.openebs.io_cstorvolumereplicas.yaml
+++ b/config/crds/bases/cstor.openebs.io_cstorvolumereplicas.yaml
@@ -8,13 +8,34 @@ metadata:
   creationTimestamp: null
   name: cstorvolumereplicas.cstor.openebs.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.capacity.total
+    description: The amount of disk space consumed by a dataset and all its descendents
+    name: Allocated
+    type: string
+  - JSONPath: .status.capacity.used
+    description: The amount of space that is logically consumed by this dataset
+    name: Used
+    type: string
+  - JSONPath: .status.phase
+    description: Identifies the current state of the replicas
+    name: Status
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: Age of CStorVolumeReplica
+    name: Age
+    type: date
   group: cstor.openebs.io
   names:
     kind: CStorVolumeReplica
     listKind: CStorVolumeReplicaList
     plural: cstorvolumereplicas
+    shortNames:
+    - cvr
     singular: cstorvolumereplica
+  preserveUnknownFields: false
   scope: Namespaced
+  subresources: {}
   validation:
     openAPIV3Schema:
       description: CStorVolumeReplica describes a cstor volume resource created as
@@ -63,13 +84,6 @@ spec:
               description: ZvolWorkers represents number of threads that executes
                 client IOs
               type: string
-          required:
-          - blockSize
-          - capacity
-          - compression
-          - replicaid
-          - targetIP
-          - zvolWorkers
           type: object
         status:
           description: CStorVolumeReplicaStatus is for handling status of cvr.
@@ -96,10 +110,12 @@ spec:
             lastTransitionTime:
               description: LastTransitionTime refers to the time when the phase changes
               format: date-time
+              nullable: true
               type: string
             lastUpdateTime:
               description: The last updated time
               format: date-time
+              nullable: true
               type: string
             message:
               description: A human readable message indicating details about the transition.
@@ -117,13 +133,8 @@ spec:
                       see. It also includes space consumed by metadata.
                     format: int64
                     type: integer
-                  used:
-                    description: Used is the used bytes for given snapshot
-                    format: int64
-                    type: integer
                 required:
                 - logicalReferenced
-                - used
                 type: object
               description: PendingSnapshots contains list of pending snapshots that
                 are not yet available on this replica
@@ -145,20 +156,12 @@ spec:
                       see. It also includes space consumed by metadata.
                     format: int64
                     type: integer
-                  used:
-                    description: Used is the used bytes for given snapshot
-                    format: int64
-                    type: integer
                 required:
                 - logicalReferenced
-                - used
                 type: object
               description: Snapshots contains list of snapshots, and their properties,
                 created on CVR
               type: object
-          required:
-          - capacity
-          - phase
           type: object
         versionDetails:
           description: VersionDetails provides the details for upgrade
@@ -185,6 +188,7 @@ spec:
                 lastUpdateTime:
                   description: LastUpdateTime is the time the status was last  updated
                   format: date-time
+                  nullable: true
                   type: string
                 message:
                   description: Message is a human readable message if some error occurs
@@ -195,20 +199,10 @@ spec:
                 state:
                   description: State is the state of reconciliation
                   type: string
-              required:
-              - current
-              - dependentsUpgraded
-              - state
               type: object
-          required:
-          - autoUpgrade
-          - desired
-          - status
           type: object
       required:
       - spec
-      - status
-      - versionDetails
       type: object
   version: v1
   versions:

--- a/config/crds/bases/cstor.openebs.io_cstorvolumes.yaml
+++ b/config/crds/bases/cstor.openebs.io_cstorvolumes.yaml
@@ -8,13 +8,30 @@ metadata:
   creationTimestamp: null
   name: cstorvolumes.cstor.openebs.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.capacity
+    description: Current volume capacity
+    name: Capacity
+    type: string
+  - JSONPath: .status.phase
+    description: Identifies the current health of the volume
+    name: Status
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: Age of CStorVolume
+    name: Age
+    type: date
   group: cstor.openebs.io
   names:
     kind: CStorVolume
     listKind: CStorVolumeList
     plural: cstorvolumes
+    shortNames:
+    - cv
     singular: cstorvolume
+  preserveUnknownFields: false
   scope: Namespaced
+  subresources: {}
   validation:
     openAPIV3Schema:
       description: CStorVolume describes a cstor volume resource created as custom
@@ -79,15 +96,6 @@ spec:
               description: iSCSI Target Portal. The Portal is combination of IP:port
                 (typically TCP ports 3260)
               type: string
-          required:
-          - capacity
-          - consistencyFactor
-          - desiredReplicationFactor
-          - iqn
-          - replicationFactor
-          - targetIP
-          - targetPort
-          - targetPortal
           type: object
         status:
           description: CStorVolumeStatus is for handling status of cvr.
@@ -140,11 +148,13 @@ spec:
             lastTransitionTime:
               description: LastTransitionTime refers to the time when the phase changes
               format: date-time
+              nullable: true
               type: string
             lastUpdateTime:
               description: LastUpdateTime refers to the time when last status updated
                 due to any operations
               format: date-time
+              nullable: true
               type: string
             message:
               description: A human-readable message indicating details about why the
@@ -206,8 +216,6 @@ spec:
                 - upTime
                 type: object
               type: array
-          required:
-          - phase
           type: object
         versionDetails:
           description: VersionDetails provides the details for upgrade
@@ -234,6 +242,7 @@ spec:
                 lastUpdateTime:
                   description: LastUpdateTime is the time the status was last  updated
                   format: date-time
+                  nullable: true
                   type: string
                 message:
                   description: Message is a human readable message if some error occurs
@@ -244,20 +253,10 @@ spec:
                 state:
                   description: State is the state of reconciliation
                   type: string
-              required:
-              - current
-              - dependentsUpgraded
-              - state
               type: object
-          required:
-          - autoUpgrade
-          - desired
-          - status
           type: object
       required:
       - spec
-      - status
-      - versionDetails
       type: object
   version: v1
   versions:

--- a/pkg/apis/cstor/v1/cstorpoolcluster.go
+++ b/pkg/apis/cstor/v1/cstorpoolcluster.go
@@ -88,10 +88,11 @@ type PoolSpec struct {
 	// NodeSelector is the labels that will be used to select
 	// a node for pool provisioning.
 	// Required field
-	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+	NodeSelector map[string]string `json:"nodeSelector"`
 	// DataRaidGroups is the raid group configuration for the given pool.
-	DataRaidGroups []RaidGroup `json:"dataRaidGroups,omitempty"`
+	DataRaidGroups []RaidGroup `json:"dataRaidGroups"`
 	// WriteCacheRaidGroups is the write cache raid group.
+	// +nullable
 	WriteCacheRaidGroups []RaidGroup `json:"writeCacheRaidGroups,omitempty"`
 	// PoolConfig is the default pool config that applies to the
 	// pool on node.

--- a/pkg/apis/cstor/v1/cstorpoolcluster.go
+++ b/pkg/apis/cstor/v1/cstorpoolcluster.go
@@ -39,40 +39,48 @@ const (
 // +genclient
 // +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +k8s:openapi-gen=true
 // +resource:path=cstorpoolcluster
 
 // CStorPoolCluster describes a CStorPoolCluster custom resource.
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:scope=Namespaced,shortName=cspc
+// +kubebuilder:printcolumn:name="HealthyInstances",type=integer,JSONPath=`.status.healthyInstances`,description="The number of healthy cStorPoolInstances"
+// +kubebuilder:printcolumn:name="ProvisionedInstances",type=integer,JSONPath=`.status.provisionedInstances`,description="The number of provisioned cStorPoolInstances"
+// +kubebuilder:printcolumn:name="DesiredInstances",type=integer,JSONPath=`.status.desiredInstances`,description="The number of desired cStorPoolInstances"
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Age of CStorPoolCluster"
 type CStorPoolCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	Spec              CStorPoolClusterSpec   `json:"spec"`
-	Status            CStorPoolClusterStatus `json:"status"`
-	VersionDetails    VersionDetails         `json:"versionDetails"`
+	Status            CStorPoolClusterStatus `json:"status,omitempty"`
+	VersionDetails    VersionDetails         `json:"versionDetails,omitempty"`
 }
 
 // CStorPoolClusterSpec is the spec for a CStorPoolClusterSpec resource
 type CStorPoolClusterSpec struct {
 	// Pools is the spec for pools for various nodes
 	// where it should be created.
-	Pools []PoolSpec `json:"pools"`
+	Pools []PoolSpec `json:"pools,omitempty"`
 	// DefaultResources are the compute resources required by the cstor-pool
 	// container.
 	// If the resources at PoolConfig is not specified, this is written
 	// to CSPI PoolConfig.
-	DefaultResources *corev1.ResourceRequirements `json:"resources"`
+	// +nullable
+	DefaultResources *corev1.ResourceRequirements `json:"resources,omitempty"`
 	// AuxResources are the compute resources required by the cstor-pool pod
 	// side car containers.
-	DefaultAuxResources *corev1.ResourceRequirements `json:"auxResources"`
+	// +nullable
+	DefaultAuxResources *corev1.ResourceRequirements `json:"auxResources,omitempty"`
 	// Tolerations, if specified, are the pool pod's tolerations
 	// If tolerations at PoolConfig is empty, this is written to
 	// CSPI PoolConfig.
-	Tolerations []corev1.Toleration `json:"tolerations"`
+	// +nullable
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 
 	// DefaultPriorityClassName if specified applies to all the pool pods
 	// in the pool spec if the priorityClass at the pool level is
 	// not specified.
-	DefaultPriorityClassName string `json:"priorityClassName"`
+	DefaultPriorityClassName string `json:"priorityClassName,omitempty"`
 }
 
 //PoolSpec is the spec for pool on node where it should be created.
@@ -80,14 +88,14 @@ type PoolSpec struct {
 	// NodeSelector is the labels that will be used to select
 	// a node for pool provisioning.
 	// Required field
-	NodeSelector map[string]string `json:"nodeSelector"`
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 	// DataRaidGroups is the raid group configuration for the given pool.
-	DataRaidGroups []RaidGroup `json:"dataRaidGroups"`
+	DataRaidGroups []RaidGroup `json:"dataRaidGroups,omitempty"`
 	// WriteCacheRaidGroups is the write cache raid group.
-	WriteCacheRaidGroups []RaidGroup `json:"writeCacheRaidGroups"`
+	WriteCacheRaidGroups []RaidGroup `json:"writeCacheRaidGroups,omitempty"`
 	// PoolConfig is the default pool config that applies to the
 	// pool on node.
-	PoolConfig PoolConfig `json:"poolConfig"`
+	PoolConfig PoolConfig `json:"poolConfig,omitempty"`
 }
 
 // PoolConfig is the default pool config that applies to the
@@ -97,29 +105,33 @@ type PoolConfig struct {
 	DataRaidGroupType string `json:"dataRaidGroupType"`
 
 	// WriteCacheGroupType is the write cache raid type.
-	WriteCacheGroupType string `json:"writeCacheGroupType"`
+	WriteCacheGroupType string `json:"writeCacheGroupType,omitempty"`
 
 	// ThickProvision to enable thick provisioning
 	// Optional -- defaults to false
-	ThickProvision bool `json:"thickProvision"`
+	ThickProvision bool `json:"thickProvision,omitempty"`
 	// Compression to enable compression
 	// Optional -- defaults to off
 	// Possible values : lz, off
-	Compression string `json:"compression"`
+	Compression string `json:"compression,omitempty"`
 	// Resources are the compute resources required by the cstor-pool
 	// container.
-	Resources *corev1.ResourceRequirements `json:"resources"`
+	// +nullable
+	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 	// AuxResources are the compute resources required by the cstor-pool pod
 	// side car containers.
-	AuxResources *corev1.ResourceRequirements `json:"auxResources"`
+	// +nullable
+	AuxResources *corev1.ResourceRequirements `json:"auxResources,omitempty"`
 	// Tolerations, if specified, the pool pod's tolerations.
-	Tolerations []corev1.Toleration `json:"tolerations"`
+	// +nullable
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 
 	// PriorityClassName if specified applies to this pool pod
 	// If left empty, DefaultPriorityClassName is applied.
 	// (See CStorPoolClusterSpec.DefaultPriorityClassName)
 	// If both are empty, not priority class is applied.
-	PriorityClassName *string `json:"priorityClassName"`
+	// +nullable
+	PriorityClassName *string `json:"priorityClassName,omitempty"`
 
 	// ROThresholdLimit is threshold(percentage base) limit
 	// for pool read only mode. If ROThresholdLimit(%) amount
@@ -128,7 +140,9 @@ type PoolConfig struct {
 	// 1. If ROThresholdLimit is set to 100 then entire
 	//    pool storage will be used by default it will be set to 85%.
 	// 2. ROThresholdLimit value will be 0 <= ROThresholdLimit <= 100.
-	ROThresholdLimit *int `json:"roThresholdLimit"` //optional
+	// +kubebuilder:validation:Optional
+	// +nullable
+	ROThresholdLimit *int `json:"roThresholdLimit,omitempty"` //optional
 }
 
 // RaidGroup contains the details of a raid group for the pool
@@ -143,24 +157,28 @@ type CStorPoolInstanceBlockDevice struct {
 	BlockDeviceName string `json:"blockDeviceName"`
 	// Capacity is the capacity of the block device.
 	// It is system generated
-	Capacity uint64 `json:"capacity"`
+	Capacity uint64 `json:"capacity,omitempty"`
 	// DevLink is the dev link for block devices
-	DevLink string `json:"devLink"`
+	DevLink string `json:"devLink,omitempty"`
 }
 
 // CStorPoolClusterStatus represents the latest available observations of a CSPC's current state.
 type CStorPoolClusterStatus struct {
 	// ProvisionedInstances is the the number of CSPI present at the current state.
-	ProvisionedInstances int32 `json:"provisionedInstances"`
+	// +nullable
+	ProvisionedInstances int32 `json:"provisionedInstances,omitempty"`
 
 	// DesiredInstances is the number of CSPI(s) that should be provisioned.
-	DesiredInstances int32 `json:"desiredInstances"`
+	// +nullable
+	DesiredInstances int32 `json:"desiredInstances,omitempty"`
 
 	// HealthyInstances is the number of CSPI(s) that are healthy.
-	HealthyInstances int32 `json:"healthyInstances"`
+	// +nullable
+	HealthyInstances int32 `json:"healthyInstances,omitempty"`
 
 	// Current state of CSPC.
-	Conditions []CStorPoolClusterCondition `json:"conditions"`
+	// +nullable
+	Conditions []CStorPoolClusterCondition `json:"conditions,omitempty"`
 }
 
 type CSPCConditionType string

--- a/pkg/apis/cstor/v1/cstorpoolinstance.go
+++ b/pkg/apis/cstor/v1/cstorpoolinstance.go
@@ -59,13 +59,14 @@ type CStorPoolInstanceSpec struct {
 	// NodeSelector is the labels that will be used to select
 	// a node for pool provisioning.
 	// Required field
-	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+	NodeSelector map[string]string `json:"nodeSelector"`
 	// PoolConfig is the default pool config that applies to the
 	// pool on node.
 	PoolConfig PoolConfig `json:"poolConfig,omitempty"`
 	// DataRaidGroups is the raid group configuration for the given pool.
-	DataRaidGroups []RaidGroup `json:"dataRaidGroups,omitempty"`
+	DataRaidGroups []RaidGroup `json:"dataRaidGroups"`
 	// WriteCacheRaidGroups is the write cache raid group.
+	// +nullable
 	WriteCacheRaidGroups []RaidGroup `json:"writeCacheRaidGroups,omitempty"`
 }
 

--- a/pkg/apis/cstor/v1/cstorpoolinstance.go
+++ b/pkg/apis/cstor/v1/cstorpoolinstance.go
@@ -25,37 +25,48 @@ import (
 // +genclient
 // +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +k8s:openapi-gen=true
 // +resource:path=cstorpoolinstance
 
 // CStorPoolInstance describes a cstor pool instance resource.
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:scope=Namespaced,shortName=cspi
+// +kubebuilder:printcolumn:name="HostName",type=string,JSONPath=`.spec.hostName`,description="Host name where cstorpool instances scheduled"
+// +kubebuilder:printcolumn:name="Allocated",type=string,JSONPath=`.status.capacity.used`,description="The amount of storage space within the pool that has been physically allocated"
+// +kubebuilder:printcolumn:name="Free",type=string,JSONPath=`.status.capacity.free`,description="The amount of usable free space available in the pool"
+// +kubebuilder:printcolumn:name="Capacity",type=string,JSONPath=`.status.capacity.total`,description="Total amount of usable space in pool"
+// +kubebuilder:printcolumn:name="ReadOnly",type=boolean,JSONPath=`.status.readOnly`,description="Identifies the pool read only mode"
+// +kubebuilder:printcolumn:name="ProvisionedReplicas",type=integer,JSONPath=`.status.provisionedReplicas`,description="Represents no.of replicas present in the pool"
+// +kubebuilder:printcolumn:name="HealthyReplicas",type=integer,JSONPath=`.status.healthyReplicas`,description="Represents no.of healthy replicas present in the pool"
+// +kubebuilder:printcolumn:name="Type",type=string,JSONPath=`.spec.poolConfig.dataRaidGroupType`,description="Represents the type of the storage pool"
+// +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.phase`,description="Identifies the current health of the pool"
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Age of CStorPoolInstance"
 type CStorPoolInstance struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// Spec is the specification of the cstorpoolinstance resource.
 	Spec CStorPoolInstanceSpec `json:"spec"`
 	// Status is the possible statuses of the cstorpoolinstance resource.
-	Status CStorPoolInstanceStatus `json:"status"`
+	Status CStorPoolInstanceStatus `json:"status,omitempty"`
 	// VersionDetails is the openebs version.
-	VersionDetails VersionDetails `json:"versionDetails"`
+	VersionDetails VersionDetails `json:"versionDetails,omitempty"`
 }
 
 // CStorPoolInstanceSpec is the spec listing fields for a CStorPoolInstance resource.
 type CStorPoolInstanceSpec struct {
 	// HostName is the name of kubernetes node where the pool
 	// should be created.
-	HostName string `json:"hostName"`
+	HostName string `json:"hostName,omitempty"`
 	// NodeSelector is the labels that will be used to select
 	// a node for pool provisioning.
 	// Required field
-	NodeSelector map[string]string `json:"nodeSelector"`
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 	// PoolConfig is the default pool config that applies to the
 	// pool on node.
-	PoolConfig PoolConfig `json:"poolConfig"`
+	PoolConfig PoolConfig `json:"poolConfig,omitempty"`
 	// DataRaidGroups is the raid group configuration for the given pool.
-	DataRaidGroups []RaidGroup `json:"dataRaidGroups"`
+	DataRaidGroups []RaidGroup `json:"dataRaidGroups,omitempty"`
 	// WriteCacheRaidGroups is the write cache raid group.
-	WriteCacheRaidGroups []RaidGroup `json:"writeCacheRaidGroups"`
+	WriteCacheRaidGroups []RaidGroup `json:"writeCacheRaidGroups,omitempty"`
 }
 
 // CStorPoolInstancePhase is the phase for CStorPoolInstance resource.
@@ -101,17 +112,17 @@ type CStorPoolInstanceStatus struct {
 	Conditions []CStorPoolInstanceCondition `json:"conditions,omitempty"`
 	//  The phase of a CStorPool is a simple, high-level summary of the pool state on the
 	//  node.
-	Phase CStorPoolInstancePhase `json:"phase"`
+	Phase CStorPoolInstancePhase `json:"phase,omitempty"`
 	// Capacity describes the capacity details of a cstor pool
-	Capacity CStorPoolInstanceCapacity `json:"capacity"`
+	Capacity CStorPoolInstanceCapacity `json:"capacity,omitempty"`
 	//ReadOnly if pool is readOnly or not
-	ReadOnly bool `json:"readOnly"`
+	ReadOnly bool `json:"readOnly,omitempty"`
 	// ProvisionedReplicas describes the total count of Volume Replicas
 	// present in the cstor pool
-	ProvisionedReplicas int32 `json:"provisionedReplicas"`
+	ProvisionedReplicas int32 `json:"provisionedReplicas,omitempty"`
 	// HealthyReplicas describes the total count of healthy Volume Replicas
 	// in the cstor pool
-	HealthyReplicas int32 `json:"healthyReplicas"`
+	HealthyReplicas int32 `json:"healthyReplicas,omitempty"`
 }
 
 // CStorPoolInstanceCapacity stores the pool capacity related attributes.

--- a/pkg/apis/cstor/v1/cstorvolume.go
+++ b/pkg/apis/cstor/v1/cstorvolume.go
@@ -26,43 +26,48 @@ import (
 // +resource:path=cstorvolume
 
 // CStorVolume describes a cstor volume resource created as custom resource
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:scope=Namespaced,shortName=cv
+// +kubebuilder:printcolumn:name="Capacity",type=string,JSONPath=`.status.capacity`,description="Current volume capacity"
+// +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.phase`,description="Identifies the current health of the volume"
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Age of CStorVolume"
 type CStorVolume struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	Spec              CStorVolumeSpec   `json:"spec"`
-	Status            CStorVolumeStatus `json:"status"`
-	VersionDetails    VersionDetails    `json:"versionDetails"`
+	Status            CStorVolumeStatus `json:"status,omitempty"`
+	VersionDetails    VersionDetails    `json:"versionDetails,omitempty"`
 }
 
 // CStorVolumeSpec is the spec for a CStorVolume resource
 type CStorVolumeSpec struct {
 	// Capacity represents the desired size of the underlying volume.
-	Capacity resource.Quantity `json:"capacity"`
+	Capacity resource.Quantity `json:"capacity,omitempty"`
 
 	// TargetIP IP of the iSCSI target service
-	TargetIP string `json:"targetIP"`
+	TargetIP string `json:"targetIP,omitempty"`
 
 	// iSCSI Target Port typically TCP ports 3260
-	TargetPort string `json:"targetPort"`
+	TargetPort string `json:"targetPort,omitempty"`
 
 	// Target iSCSI Qualified Name.combination of nodeBase
-	Iqn string `json:"iqn"`
+	Iqn string `json:"iqn,omitempty"`
 
 	// iSCSI Target Portal. The Portal is combination of IP:port (typically TCP ports 3260)
-	TargetPortal string `json:"targetPortal"`
+	TargetPortal string `json:"targetPortal,omitempty"`
 
 	// ReplicationFactor represents number of volume replica created during volume
 	// provisioning connect to the target
-	ReplicationFactor int `json:"replicationFactor"`
+	ReplicationFactor int `json:"replicationFactor,omitempty"`
 
 	// ConsistencyFactor is minimum number of volume replicas i.e. `RF/2 + 1`
 	// has to be connected to the target for write operations. Basically more then
 	// 50% of replica has to be connected to target.
-	ConsistencyFactor int `json:"consistencyFactor"`
+	ConsistencyFactor int `json:"consistencyFactor,omitempty"`
 
 	// DesiredReplicationFactor represents maximum number of replicas
 	// that are allowed to connect to the target. Required for scale operations
-	DesiredReplicationFactor int `json:"desiredReplicationFactor"`
+	DesiredReplicationFactor int `json:"desiredReplicationFactor,omitempty"`
 
 	//ReplicaDetails refers to the trusty replica information
 	ReplicaDetails CStorVolumeReplicaDetails `json:"replicaDetails,omitempty"`
@@ -76,14 +81,16 @@ type CStorVolumePhase string
 
 // CStorVolumeStatus is for handling status of cvr.
 type CStorVolumeStatus struct {
-	Phase           CStorVolumePhase `json:"phase"`
+	Phase           CStorVolumePhase `json:"phase,omitempty"`
 	ReplicaStatuses []ReplicaStatus  `json:"replicaStatuses,omitempty"`
 	// Represents the actual capacity of the underlying volume.
 	Capacity resource.Quantity `json:"capacity,omitempty"`
 	// LastTransitionTime refers to the time when the phase changes
+	// +nullable
 	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty"`
 	// LastUpdateTime refers to the time when last status updated due to any
 	// operations
+	// +nullable
 	LastUpdateTime metav1.Time `json:"lastUpdateTime,omitempty"`
 	// A human-readable message indicating details about why the volume is in this state.
 	Message string `json:"message,omitempty"`

--- a/pkg/apis/cstor/v1/cstorvolumeconfig.go
+++ b/pkg/apis/cstor/v1/cstorvolumeconfig.go
@@ -23,11 +23,15 @@ import (
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +k8s:openapi-gen=true
 
 // CStorVolumeConfig describes a cstor volume config resource created as
 // custom resource. CStorVolumeConfig is a request for creating cstor volume
 // related resources like deployment, svc etc.
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:scope=Namespaced,shortName=cvc
+// +kubebuilder:printcolumn:name="Capacity",type=string,JSONPath=`.status.capacity.storage`,description="Identifies the volume capacity"
+// +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.phase`,description="Identifies the volume provisioning status"
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Age of CStorVolumeReplica"
 type CStorVolumeConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -103,10 +107,10 @@ const (
 // defines the observed state of CStorVolumeConfig
 type CStorVolumeConfigStatus struct {
 	// Phase represents the current phase of CStorVolumeConfig.
-	Phase CStorVolumeConfigPhase `json:"phase"`
+	Phase CStorVolumeConfigPhase `json:"phase,omitempty"`
 
 	// PoolInfo represents current pool names where volume replicas exists
-	PoolInfo []string `json:"poolInfo"`
+	PoolInfo []string `json:"poolInfo,omitempty"`
 
 	// Capacity the actual resources of the underlying volume.
 	Capacity corev1.ResourceList `json:"capacity,omitempty"`

--- a/pkg/apis/cstor/v1/cstorvolumepolicy.go
+++ b/pkg/apis/cstor/v1/cstorvolumepolicy.go
@@ -23,34 +23,35 @@ import (
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +k8s:openapi-gen=true
 
 // CStorVolumePolicy describes a configuration required for cstor volume
 // resources
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:scope=Namespaced,shortName=cvp
 type CStorVolumePolicy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// Spec defines a configuration info of a cstor volume required
 	// to provisione cstor volume resources
 	Spec   CStorVolumePolicySpec   `json:"spec"`
-	Status CStorVolumePolicyStatus `json:"status"`
+	Status CStorVolumePolicyStatus `json:"status,omitempty"`
 }
 
 // CStorVolumePolicySpec ...
 type CStorVolumePolicySpec struct {
 	// replicaAffinity is set to true then volume replica resources need to be
 	// distributed across the pool instances
-	Provision Provision `json:"provision"`
+	Provision Provision `json:"provision,omitempty"`
 
 	// TargetSpec represents configuration related to cstor target and its resources
-	Target TargetSpec `json:"target"`
+	Target TargetSpec `json:"target,omitempty"`
 
 	// ReplicaSpec represents configuration related to replicas resources
-	Replica ReplicaSpec `json:"replica"`
+	Replica ReplicaSpec `json:"replica,omitempty"`
 
 	// ReplicaPoolInfo holds the pool information of volume replicas.
 	// Ex: If volume is provisioned on which CStor pool volume replicas exist
-	ReplicaPoolInfo []ReplicaPoolInfo `json:"replicaPoolInfo"`
+	ReplicaPoolInfo []ReplicaPoolInfo `json:"replicaPoolInfo,omitempty"`
 }
 
 // TargetSpec represents configuration related to cstor target and its resources
@@ -151,11 +152,10 @@ type ReplicaPoolInfo struct {
 
 // CStorVolumePolicyStatus is for handling status of CstorVolumePolicy
 type CStorVolumePolicyStatus struct {
-	Phase string `json:"phase"`
+	Phase string `json:"phase,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +k8s:openapi-gen=true
 
 // CStorVolumePolicyList is a list of CStorVolumePolicy resources
 type CStorVolumePolicyList struct {

--- a/pkg/apis/cstor/v1/cstorvolumereplica.go
+++ b/pkg/apis/cstor/v1/cstorvolumereplica.go
@@ -41,34 +41,40 @@ const (
 // +resource:path=cstorvolumereplica
 
 // CStorVolumeReplica describes a cstor volume resource created as custom resource
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:scope=Namespaced,shortName=cvr
+// +kubebuilder:printcolumn:name="Allocated",type=string,JSONPath=`.status.capacity.total`,description="The amount of disk space consumed by a dataset and all its descendents"
+// +kubebuilder:printcolumn:name="Used",type=string,JSONPath=`.status.capacity.used`,description="The amount of space that is logically consumed by this dataset"
+// +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.phase`,description="Identifies the current state of the replicas"
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Age of CStorVolumeReplica"
 type CStorVolumeReplica struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	Spec              CStorVolumeReplicaSpec   `json:"spec"`
-	Status            CStorVolumeReplicaStatus `json:"status"`
-	VersionDetails    VersionDetails           `json:"versionDetails"`
+	Status            CStorVolumeReplicaStatus `json:"status,omitempty"`
+	VersionDetails    VersionDetails           `json:"versionDetails,omitempty"`
 }
 
 // CStorVolumeReplicaSpec is the spec for a CStorVolumeReplica resource
 type CStorVolumeReplicaSpec struct {
 	// TargetIP represents iscsi target IP through which replica cummunicates
 	// IO workloads and other volume operations like snapshot and resize requests
-	TargetIP string `json:"targetIP"`
+	TargetIP string `json:"targetIP,omitempty"`
 	//Represents the actual capacity of the underlying volume
-	Capacity string `json:"capacity"`
+	Capacity string `json:"capacity,omitempty"`
 	// ZvolWorkers represents number of threads that executes client IOs
-	ZvolWorkers string `json:"zvolWorkers"`
+	ZvolWorkers string `json:"zvolWorkers,omitempty"`
 	// ReplicaID is unique number to identify the replica
-	ReplicaID string `json:"replicaid"`
+	ReplicaID string `json:"replicaid,omitempty"`
 	// Controls the compression algorithm used for this volumes
 	// examples: on|off|gzip|gzip-N|lz4|lzjb|zle
-	Compression string `json:"compression"`
+	Compression string `json:"compression,omitempty"`
 	// BlockSize is the logical block size in multiple of 512 bytes
 	// BlockSize specifies the block size of the volume. The blocksize
 	// cannot be changed once the volume has been written, so it should be
 	// set at volume creation time. The default blocksize for volumes is 4 Kbytes.
 	// Any power of 2 from 512 bytes to 128 Kbytes is valid.
-	BlockSize uint32 `json:"blockSize"`
+	BlockSize uint32 `json:"blockSize,omitempty"`
 }
 
 // CStorVolumeReplicaPhase is to hold result of action.
@@ -131,15 +137,17 @@ const (
 // CStorVolumeReplicaStatus is for handling status of cvr.
 type CStorVolumeReplicaStatus struct {
 	// CStorVolumeReplicaPhase is to holds different phases of replica
-	Phase CStorVolumeReplicaPhase `json:"phase"`
+	Phase CStorVolumeReplicaPhase `json:"phase,omitempty"`
 
 	// CStorVolumeCapacityDetails represents capacity info of replica
-	Capacity CStorVolumeReplicaCapacityDetails `json:"capacity"`
+	Capacity CStorVolumeReplicaCapacityDetails `json:"capacity,omitempty"`
 
 	// LastTransitionTime refers to the time when the phase changes
+	// +nullable
 	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty"`
 
 	// The last updated time
+	// +nullable
 	LastUpdateTime metav1.Time `json:"lastUpdateTime,omitempty"`
 
 	// A human readable message indicating details about the transition.

--- a/pkg/apis/cstor/v1/version_details_types.go
+++ b/pkg/apis/cstor/v1/version_details_types.go
@@ -22,29 +22,30 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 type VersionDetails struct {
 	// If AutoUpgrade is set to true then the resource is
 	// upgraded automatically without any manual steps
-	AutoUpgrade bool `json:"autoUpgrade"`
+	AutoUpgrade bool `json:"autoUpgrade,omitempty"`
 	// Desired is the version that we want to
 	// upgrade or the control plane version
-	Desired string `json:"desired"`
+	Desired string `json:"desired,omitempty"`
 	// Status gives the status of reconciliation triggered
 	// when the desired and current version are not same
-	Status VersionStatus `json:"status"`
+	Status VersionStatus `json:"status,omitempty"`
 }
 
 // VersionStatus is the status of the reconciliation of versions
 type VersionStatus struct {
 	// DependentsUpgraded gives the details whether all children
 	// of a resource are upgraded to desired version or not
-	DependentsUpgraded bool `json:"dependentsUpgraded"`
+	DependentsUpgraded bool `json:"dependentsUpgraded,omitempty"`
 	// Current is the version of resource
-	Current string `json:"current"`
+	Current string `json:"current,omitempty"`
 	// State is the state of reconciliation
-	State VersionState `json:"state"`
+	State VersionState `json:"state,omitempty"`
 	// Message is a human readable message if some error occurs
 	Message string `json:"message,omitempty"`
 	// Reason is the actual reason for the error state
 	Reason string `json:"reason,omitempty"`
 	// LastUpdateTime is the time the status was last  updated
+	// +nullable
 	LastUpdateTime metav1.Time `json:"lastUpdateTime,omitempty"`
 }
 


### PR DESCRIPTION
Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>

- add custom columns
- add `omitempty` json tags following the APIs practices
- add nullable tags in array and time data types to accept them as null value

**Note:**  `all_crd.yaml` file will be maintained in cstor-operators repo for the further dev/release uses, and 
                later we can automate the generation in cstor-operators repo itself.

**Tests**
Minimal spec yaml which has been tested

```yaml
---
apiVersion: cstor.openebs.io/v1
kind: CStorPoolCluster
metadata:
  name: cspc-sparse-stripe
  namespace: openebs
spec:
  pools:
    - nodeSelector:
        kubernetes.io/hostname: "127.0.0.1"
      dataRaidGroups:
      - blockDevices:
          - blockDeviceName: "sparse-5a92ced3e2ee21eac7b930f670b5eab5"
      poolConfig:
        dataRaidGroupType: "stripe"
```