### PR TITLE
fix(crd): remove omitempty tag from CSPI status fields

### DIFF
--- a/config/crds/all-crds.yaml
+++ b/config/crds/all-crds.yaml
@@ -884,6 +884,10 @@ spec:
             readOnly:
               description: ReadOnly if pool is readOnly or not
               type: boolean
+          required:
+          - healthyReplicas
+          - provisionedReplicas
+          - readOnly
           type: object
         versionDetails:
           description: VersionDetails is the openebs version.

--- a/config/crds/all-crds.yaml
+++ b/config/crds/all-crds.yaml
@@ -509,6 +509,7 @@ spec:
     description: The amount of storage space within the pool that has been physically
       allocated
     name: Allocated
+    priority: 1
     type: string
   - JSONPath: .status.capacity.free
     description: The amount of usable free space available in the pool
@@ -533,6 +534,7 @@ spec:
   - JSONPath: .spec.poolConfig.dataRaidGroupType
     description: Represents the type of the storage pool
     name: Type
+    priority: 1
     type: string
   - JSONPath: .status.phase
     description: Identifies the current health of the pool

--- a/config/crds/bases/cstor.openebs.io_cstorpoolinstances.yaml
+++ b/config/crds/bases/cstor.openebs.io_cstorpoolinstances.yaml
@@ -392,6 +392,10 @@ spec:
             readOnly:
               description: ReadOnly if pool is readOnly or not
               type: boolean
+          required:
+          - healthyReplicas
+          - provisionedReplicas
+          - readOnly
           type: object
         versionDetails:
           description: VersionDetails is the openebs version.

--- a/config/crds/bases/cstor.openebs.io_cstorpoolinstances.yaml
+++ b/config/crds/bases/cstor.openebs.io_cstorpoolinstances.yaml
@@ -17,6 +17,7 @@ spec:
     description: The amount of storage space within the pool that has been physically
       allocated
     name: Allocated
+    priority: 1
     type: string
   - JSONPath: .status.capacity.free
     description: The amount of usable free space available in the pool
@@ -41,6 +42,7 @@ spec:
   - JSONPath: .spec.poolConfig.dataRaidGroupType
     description: Represents the type of the storage pool
     name: Type
+    priority: 1
     type: string
   - JSONPath: .status.phase
     description: Identifies the current health of the pool

--- a/pkg/apis/cstor/v1/cstorpoolinstance.go
+++ b/pkg/apis/cstor/v1/cstorpoolinstance.go
@@ -31,13 +31,13 @@ import (
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Namespaced,shortName=cspi
 // +kubebuilder:printcolumn:name="HostName",type=string,JSONPath=`.spec.hostName`,description="Host name where cstorpool instances scheduled"
-// +kubebuilder:printcolumn:name="Allocated",type=string,JSONPath=`.status.capacity.used`,description="The amount of storage space within the pool that has been physically allocated"
+// +kubebuilder:printcolumn:name="Allocated",type=string,JSONPath=`.status.capacity.used`,description="The amount of storage space within the pool that has been physically allocated",priority=1
 // +kubebuilder:printcolumn:name="Free",type=string,JSONPath=`.status.capacity.free`,description="The amount of usable free space available in the pool"
 // +kubebuilder:printcolumn:name="Capacity",type=string,JSONPath=`.status.capacity.total`,description="Total amount of usable space in pool"
 // +kubebuilder:printcolumn:name="ReadOnly",type=boolean,JSONPath=`.status.readOnly`,description="Identifies the pool read only mode"
 // +kubebuilder:printcolumn:name="ProvisionedReplicas",type=integer,JSONPath=`.status.provisionedReplicas`,description="Represents no.of replicas present in the pool"
 // +kubebuilder:printcolumn:name="HealthyReplicas",type=integer,JSONPath=`.status.healthyReplicas`,description="Represents no.of healthy replicas present in the pool"
-// +kubebuilder:printcolumn:name="Type",type=string,JSONPath=`.spec.poolConfig.dataRaidGroupType`,description="Represents the type of the storage pool"
+// +kubebuilder:printcolumn:name="Type",type=string,JSONPath=`.spec.poolConfig.dataRaidGroupType`,description="Represents the type of the storage pool",priority=1
 // +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.phase`,description="Identifies the current health of the pool"
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Age of CStorPoolInstance"
 type CStorPoolInstance struct {

--- a/pkg/apis/cstor/v1/cstorpoolinstance.go
+++ b/pkg/apis/cstor/v1/cstorpoolinstance.go
@@ -117,13 +117,13 @@ type CStorPoolInstanceStatus struct {
 	// Capacity describes the capacity details of a cstor pool
 	Capacity CStorPoolInstanceCapacity `json:"capacity,omitempty"`
 	//ReadOnly if pool is readOnly or not
-	ReadOnly bool `json:"readOnly,omitempty"`
+	ReadOnly bool `json:"readOnly"`
 	// ProvisionedReplicas describes the total count of Volume Replicas
 	// present in the cstor pool
-	ProvisionedReplicas int32 `json:"provisionedReplicas,omitempty"`
+	ProvisionedReplicas int32 `json:"provisionedReplicas"`
 	// HealthyReplicas describes the total count of healthy Volume Replicas
 	// in the cstor pool
-	HealthyReplicas int32 `json:"healthyReplicas,omitempty"`
+	HealthyReplicas int32 `json:"healthyReplicas"`
 }
 
 // CStorPoolInstanceCapacity stores the pool capacity related attributes.


### PR DESCRIPTION
This PR does the following changes:
- Removes the omitempty tag on CSPI status fields.
If `omitempty` tag is provided then default values are
not shown in the output of `kubectl get cspi <cspi_name> -o yaml`.
- Set the priority value as 1 for `ALLOCATED and TYPE` printer columns.

Without this PR output of cspi:
```sh
kubectl get cspi -n openebs
NAME                     HOSTNAME    ALLOCATED   FREE    CAPACITY     READONLY   PROVISIONEDREPLICAS   HEALTHYREPLICAS   TYPE     STATUS   AGE
cstor-sparse-cspc-bwtn   127.0.0.1   81500       9630M   9630081500                                                      mirror   ONLINE   12m
```
With changes in this PR:
```sh
kubectl get cspi -n openebs
NAME                     HOSTNAME          FREE     CAPACITY     READONLY   PROVISIONEDREPLICAS   HEALTHYREPLICAS   STATUS   AGE
cstor-sparse-cspc-bwtn   centos-worker-1   9630M    9630084500   false      0                     0                 ONLINE   24m
```
For more information about the pool:
```sh
kubectl get cspi -n openebs -o wide
 kubectl get cspi -n openebs -o wide
NAME                     HOSTNAME          ALLOCATED   FREE     CAPACITY    READONLY   PROVISIONEDREPLICAS   HEALTHYREPLICAS   TYPE     STATUS   AGE
sparse-based-pool-n5q7   centos-worker-1   89k         9630M    9630089k    false      0                     0                 stripe   ONLINE   28m
```

*Note to reviewers*:
- Deployed the cstor-operator of 1.12.0 version YAMLs and CRDs.
- Provisioned the CSPC based pool.
- Upgraded the control plane to use modified CRDs and images(images were built locally).
Observation: No errors were shown on the logs and able to create CSPI without status.
- Upgraded the CSPC to the latest version. CSPC was upgraded and no errors were shown


Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>