### PR TITLE
chore(ci): add license check in ci

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -25,6 +25,9 @@ jobs:
     - name: verify dependencies
       run: make deps
 
+    - name: verify license
+      run: make license-check-go
+
     - name: verify kubegen
       run: make verify_kubegen
       env:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.13
+    - name: Set up Go 1.14
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13.6
+        go-version: 1.14.7
       id: go
 
     - name: Check out code into the Go module directory

--- a/Makefile
+++ b/Makefile
@@ -56,3 +56,19 @@ deps:
 .PHONY: test
 test:
 	go test ./...
+
+.PHONY: build.common
+build.common: license-check-go
+	
+.PHONY: license-check-go
+license-check-go:
+	@echo "--> Checking license header..."
+	@licRes=$$(for file in $$(find . -type f -iname '*.go' ! -path './vendor/*' ! -path './hack/tools.go' ) ; do \
+               awk 'NR<=3' $$file | grep -Eq "(Copyright|generated|GENERATED)" || echo $$file; \
+       done); \
+       if [ -n "$${licRes}" ]; then \
+               echo "license header checking failed:"; echo "$${licRes}"; \
+               exit 1; \
+       fi
+	@echo "--> Done checking license."
+	@echo


### PR DESCRIPTION
This PR adds license-check in CI
How test was done:
- Added license check in Makefile to look for files having license .
- If license found then Build passes.
- Else Build fails.
The command to test license is `make license-check-go`
