### PR TITLE
License check

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -25,6 +25,9 @@ jobs:
     - name: verify dependencies
       run: make deps
 
+    - name: verify license
+      run: make license-check-go
+
     - name: verify kubegen
       run: make verify_kubegen
       env:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,7 +26,7 @@ jobs:
       run: make deps
 
     - name: verify license
-      run: make license-check-go
+      run: make license-check
 
     - name: verify kubegen
       run: make verify_kubegen

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.13
+    - name: Set up Go 1.14
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13.6
+        go-version: 1.14.7
       id: go
 
     - name: Check out code into the Go module directory

--- a/Makefile
+++ b/Makefile
@@ -56,15 +56,12 @@ deps:
 .PHONY: test
 test:
 	go test ./...
-
-.PHONY: build.common
-build.common: license-check-go
 	
-.PHONY: license-check-go
-license-check-go:
+.PHONY: license-check
+license-check:
 	@echo "--> Checking license header..."
-	@licRes=$$(for file in $$(find . -type f -iname '*.go' ! -path './vendor/*' ! -path './hack/tools.go' ) ; do \
-               awk 'NR<=3' $$file | grep -Eq "(Copyright|generated|GENERATED)" || echo $$file; \
+	@licRes=$$(for file in $$(find . -type f -regex '.*\.sh\|.*\.go\|.*Docker.*\|.*\Makefile*' ! -path './vendor/*' ! -path './hack/tools.go' ) ; do \
+               awk 'NR<=5' $$file | grep -Eq "(Copyright|generated|GENERATED)" || echo $$file; \
        done); \
        if [ -n "$${licRes}" ]; then \
                echo "license header checking failed:"; echo "$${licRes}"; \

--- a/Makefile
+++ b/Makefile
@@ -56,3 +56,19 @@ deps:
 .PHONY: test
 test:
 	go test ./...
+
+.PHONY: build.common
+build.common: license-check-go
+	
+.PHONY: license-check-go
+license-check-go:
+	@echo "--> Checking license header..."
+	@licRes=$$(for file in $$(find . -type f -iname '*.go' ! -path './vendor/*' ! -path './hack/tools.go' ) ; do \
+               awk 'NR<=3' $$file | grep -Eq "(Copyright|generated|GENERATED)" || echo $$file; \
+       done); \
+       if [ -n "$${licRes}" ]; then \
+               echo "license header checking failed:"; echo "$${licRes}"; \
+               exit 1; \
+       fi
+	@echo "--> Done checking license."
+	@echo

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ test:
 .PHONY: license-check
 license-check:
 	@echo "--> Checking license header..."
-	@licRes=$$(for file in $$(find . -type f -regex '.*\.sh\|.*\.go\|.*Docker.*\|.*\Makefile*' ! -path './vendor/*' ! -path './hack/tools.go' ) ; do \
+	@licRes=$$(for file in $$(find . -type f -regex '.*\.sh\|.*\.go\|.*Docker.*\|.*\Makefile*' ! -path './vendor/*') ; do \
                awk 'NR<=5' $$file | grep -Eq "(Copyright|generated|GENERATED)" || echo $$file; \
        done); \
        if [ -n "$${licRes}" ]; then \


### PR DESCRIPTION
This PR adds license-check for .sh and Dockerfile.
How the test was done:
- Added license-check in `Makefile` to look for the files with license.
- If license found then build passes,  else build fails.
- license-check was done for .go, .sh, Dockerfile.

The command to test license-check is  
`make license-check`