### PR TITLE
Export all CRDs including `*.openebs.io` to `all-crds.yaml`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ generate: generate-crds
 
 generate-crds: controller-gen
 	# Generate manifests e.g. CRD, RBAC etc.
-	$(CONTROLLER_GEN) crd:trivialVersions=true,preserveUnknownFields=false paths="./pkg/apis/cstor/..." output:crd:artifacts:config=config/crds/bases
+	$(CONTROLLER_GEN) crd:trivialVersions=true,preserveUnknownFields=false paths="./pkg/apis/..." output:crd:artifacts:config=config/crds/bases
 	# merge all crds into a single file
 	rm $(ALL_CRDS)
 	cat config/crds/bases/*.yaml >> $(ALL_CRDS)
@@ -61,7 +61,7 @@ deps:
 .PHONY: test
 test:
 	go test ./...
-	
+
 .PHONY: license-check
 license-check:
 	@echo "--> Checking license header..."

--- a/config/crds/all-crds.yaml
+++ b/config/crds/all-crds.yaml
@@ -2779,3 +2779,1039 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
+  name: blockdeviceclaims.openebs.io
+spec:
+  group: openebs.io
+  names:
+    kind: BlockDeviceClaim
+    listKind: BlockDeviceClaimList
+    plural: blockdeviceclaims
+    singular: blockdeviceclaim
+  preserveUnknownFields: false
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: BlockDeviceClaim is the Schema for the BlockDeviceClaim CR
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: DeviceClaimSpec defines the request details for a BlockDevice
+          properties:
+            blockDeviceName:
+              description: BlockDeviceName is the reference to the block-device backing
+                this claim
+              type: string
+            blockDeviceNodeAttributes:
+              description: BlockDeviceNodeAttributes is the attributes on the node
+                from which a BD should be selected for this claim. It can include
+                nodename, failure domain etc.
+              properties:
+                hostName:
+                  description: HostName represents the hostname of the Kubernetes
+                    node resource where the BD should be present
+                  type: string
+                nodeName:
+                  description: NodeName represents the name of the Kubernetes node
+                    resource where the BD should be present
+                  type: string
+              type: object
+            deviceClaimDetails:
+              description: Details of the device to be claimed
+              properties:
+                allowPartition:
+                  description: AllowPartition represents whether to claim a full block
+                    device or a device that is a partition
+                  type: boolean
+                blockVolumeMode:
+                  description: 'BlockVolumeMode represents whether to claim a device
+                    in Block mode or Filesystem mode. These are use cases of BlockVolumeMode:
+                    1) Not specified: VolumeMode check will not be effective 2) VolumeModeBlock:
+                    BD should not have any filesystem or mountpoint 3) VolumeModeFileSystem:
+                    BD should have a filesystem and mountpoint. If DeviceFormat is    specified
+                    then the format should match with the FSType in BD'
+                  type: string
+                formatType:
+                  description: Format of the device required, eg:ext4, xfs
+                  type: string
+              type: object
+            deviceType:
+              description: DeviceType represents the type of drive like SSD, HDD etc.,
+              type: string
+            hostName:
+              description: HostName from where blockdevice has to be claimed.
+              type: string
+            resources:
+              description: Resources will help with placing claims on Capacity, IOPS
+              properties:
+                requests:
+                  additionalProperties:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: 'Requests describes the minimum resources required.
+                    eg: if storage resource of 10G is requested minimum capacity of
+                    10G should be available'
+                  type: object
+              required:
+              - requests
+              type: object
+            selector:
+              description: Selector is used to find block devices to be considered
+                for claiming
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                    type: object
+                  type: array
+                matchLabels:
+                  additionalProperties:
+                    type: string
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
+                  type: object
+              type: object
+          required:
+          - deviceType
+          - hostName
+          - resources
+          type: object
+        status:
+          description: DeviceClaimStatus defines the observed state of BlockDeviceClaim
+          properties:
+            phase:
+              description: DeviceClaimPhase is a typed string for phase field of BlockDeviceClaim.
+              type: string
+          required:
+          - phase
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
+  name: blockdevices.openebs.io
+spec:
+  group: openebs.io
+  names:
+    kind: BlockDevice
+    listKind: BlockDeviceList
+    plural: blockdevices
+    singular: blockdevice
+  preserveUnknownFields: false
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: BlockDevice is the Schema used to represent a BlockDevice CR
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: DeviceSpec defines the properties and runtime status of a BlockDevice
+          properties:
+            aggregateDevice:
+              description: AggregateDevice was intended to store the hierachical information
+                in cases of LVM. However this is currently not implemented and may
+                need to be re-looked into for better design. TODO @kmova to be implemented/deprecated
+              type: string
+            capacity:
+              description: Capacity
+              properties:
+                logicalSectorSize:
+                  description: LogicalSectorSize is blockdevice logical-sector size
+                    in bytes
+                  format: int32
+                  type: integer
+                physicalSectorSize:
+                  description: PhysicalSectorSize is blockdevice physical-Sector size
+                    in bytes
+                  format: int32
+                  type: integer
+                storage:
+                  description: Storage is the blockdevice capacity in bytes
+                  format: int64
+                  type: integer
+              required:
+              - logicalSectorSize
+              - physicalSectorSize
+              - storage
+              type: object
+            claimRef:
+              description: Reference to the BDC which has claimed this BD
+              properties:
+                apiVersion:
+                  description: API version of the referent.
+                  type: string
+                fieldPath:
+                  description: 'If referring to a piece of an object instead of an
+                    entire object, this string should contain a valid JSON/Go field
+                    access statement, such as desiredState.manifest.containers[2].
+                    For example, if the object reference is to a container within
+                    a pod, this would take on a value like: "spec.containers{name}"
+                    (where "name" refers to the name of the container that triggered
+                    the event) or if no container name is specified "spec.containers[2]"
+                    (container with index 2 in this pod). This syntax is chosen only
+                    to have some well-defined way of referencing a part of an object.
+                    TODO: this design is not final and this field is subject to change
+                    in the future.'
+                  type: string
+                kind:
+                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+                resourceVersion:
+                  description: 'Specific resourceVersion to which this reference is
+                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                  type: string
+                uid:
+                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                  type: string
+              type: object
+            details:
+              description: Details contain static attributes of BD like model,serial,
+                and so forth
+              properties:
+                compliance:
+                  description: Compliance is standards/specifications version implmented
+                    by device firmware  such as SPC-1, SPC-2, etc
+                  type: string
+                deviceType:
+                  description: DeviceType represents the type of device like sparse,
+                    disk, partition, lvm, raid
+                  type: string
+                driveType:
+                  description: DriveType is the type of backing drive, HDD/SSD
+                  type: string
+                firmwareRevision:
+                  description: disk firmware revision
+                  type: string
+                hardwareSectorSize:
+                  description: HardwareSectorSize is the hardware sector size in bytes
+                  format: int32
+                  type: integer
+                logicalBlockSize:
+                  description: LogicalBlockSize is the logical block size in bytes
+                    reported by /sys/class/block/sda/queue/logical_block_size
+                  format: int32
+                  type: integer
+                model:
+                  description: Model is model of disk
+                  type: string
+                physicalBlockSize:
+                  description: PhysicalBlockSize is the physical block size in bytes
+                    reported by /sys/class/block/sda/queue/physical_block_size
+                  format: int32
+                  type: integer
+                serial:
+                  description: Serial is serial number of disk
+                  type: string
+                vendor:
+                  description: Vendor is vendor of disk
+                  type: string
+              required:
+              - compliance
+              - deviceType
+              - driveType
+              - firmwareRevision
+              - hardwareSectorSize
+              - logicalBlockSize
+              - model
+              - physicalBlockSize
+              - serial
+              - vendor
+              type: object
+            devlinks:
+              description: DevLinks contains soft links of a block device like /dev/by-id/...
+                /dev/by-uuid/...
+              items:
+                description: DeviceDevLink holds the maping between type and links
+                  like by-id type or by-path type link
+                properties:
+                  kind:
+                    description: Kind is the type of link like by-id or by-path.
+                    type: string
+                  links:
+                    description: Links are the soft links of Type type
+                    items:
+                      type: string
+                    type: array
+                type: object
+              type: array
+            filesystem:
+              description: FileSystem contains mountpoint and filesystem type
+              properties:
+                fsType:
+                  description: Type represents the FileSystem type of the block device
+                  type: string
+                mountPoint:
+                  description: MountPoint represents the mountpoint of the block device.
+                  type: string
+              type: object
+            nodeAttributes:
+              description: NodeAttributes has the details of the node on which BD
+                is attached
+              properties:
+                nodeName:
+                  description: NodeName is the name of the Kubernetes node resource
+                    on which the device is attached
+                  type: string
+              required:
+              - nodeName
+              type: object
+            parentDevice:
+              description: "ParentDevice was intented to store the UUID of the parent
+                Block Device as is the case for partitioned block devices. \n For
+                example: /dev/sda is the parent for /dev/sdap1 TODO @kmova to be implemented/deprecated"
+              type: string
+            partitioned:
+              description: Partitioned represents if BlockDevice has partions or not
+                (YES/NO) Currently always default to NO. TODO @kmova to be implemented/deprecated
+              type: string
+            path:
+              description: Path contain devpath (e.g. /dev/sdb)
+              type: string
+          required:
+          - capacity
+          - details
+          - devlinks
+          - nodeAttributes
+          - partitioned
+          - path
+          type: object
+        status:
+          description: DeviceStatus defines the observed state of BlockDevice
+          properties:
+            claimState:
+              description: claim state of the block device
+              type: string
+            state:
+              description: State is the current state of the blockdevice (Active/Inactive)
+              type: string
+          required:
+          - claimState
+          - state
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
+  name: cstorbackups.openebs.io
+spec:
+  group: openebs.io
+  names:
+    kind: CStorBackup
+    listKind: CStorBackupList
+    plural: cstorbackups
+    singular: cstorbackup
+  preserveUnknownFields: false
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: CStorBackup describes a cstor backup resource created as a custom
+        resource
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: CStorBackupSpec is the spec for a CStorBackup resource
+          properties:
+            backupDest:
+              description: BackupDest is the remote address for backup transfer
+              type: string
+            backupName:
+              description: BackupName is a name of the backup or scheduled backup
+              type: string
+            localSnap:
+              description: LocalSnap is flag to enable local snapshot only
+              type: boolean
+            prevSnapName:
+              description: PrevSnapName is the last completed-backup's snapshot name
+              type: string
+            snapName:
+              description: SnapName is a name of the current backup snapshot
+              type: string
+            volumeName:
+              description: VolumeName is a name of the volume for which this backup
+                is destined
+              type: string
+          required:
+          - backupDest
+          - backupName
+          - localSnap
+          - prevSnapName
+          - snapName
+          - volumeName
+          type: object
+        status:
+          description: CStorBackupStatus is to hold status of backup
+          type: string
+      required:
+      - spec
+      - status
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
+  name: cstorcompletedbackups.openebs.io
+spec:
+  group: openebs.io
+  names:
+    kind: CStorCompletedBackup
+    listKind: CStorCompletedBackupList
+    plural: cstorcompletedbackups
+    singular: cstorcompletedbackup
+  preserveUnknownFields: false
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: CStorCompletedBackup describes a cstor completed-backup resource
+        created as custom resource
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: CStorBackupSpec is the spec for a CStorBackup resource
+          properties:
+            backupDest:
+              description: BackupDest is the remote address for backup transfer
+              type: string
+            backupName:
+              description: BackupName is a name of the backup or scheduled backup
+              type: string
+            localSnap:
+              description: LocalSnap is flag to enable local snapshot only
+              type: boolean
+            prevSnapName:
+              description: PrevSnapName is the last completed-backup's snapshot name
+              type: string
+            snapName:
+              description: SnapName is a name of the current backup snapshot
+              type: string
+            volumeName:
+              description: VolumeName is a name of the volume for which this backup
+                is destined
+              type: string
+          required:
+          - backupDest
+          - backupName
+          - localSnap
+          - prevSnapName
+          - snapName
+          - volumeName
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
+  name: cstorrestores.openebs.io
+spec:
+  group: openebs.io
+  names:
+    kind: CStorRestore
+    listKind: CStorRestoreList
+    plural: cstorrestores
+    singular: cstorrestore
+  preserveUnknownFields: false
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: CStorRestore describes a cstor restore resource created as a custom
+        resource
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: CStorRestoreSpec is the spec for a CStorRestore resource
+          properties:
+            localRestore:
+              type: boolean
+            maxretrycount:
+              type: integer
+            restoreName:
+              type: string
+            restoreSrc:
+              type: string
+            retrycount:
+              type: integer
+            size:
+              anyOf:
+              - type: integer
+              - type: string
+              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+              x-kubernetes-int-or-string: true
+            storageClass:
+              type: string
+            volumeName:
+              type: string
+          required:
+          - maxretrycount
+          - restoreName
+          - restoreSrc
+          - retrycount
+          - volumeName
+          type: object
+        status:
+          description: CStorRestoreStatus is to hold result of action.
+          type: string
+      required:
+      - spec
+      - status
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
+  name: migrationtasks.openebs.io
+spec:
+  group: openebs.io
+  names:
+    kind: MigrationTask
+    listKind: MigrationTaskList
+    plural: migrationtasks
+    shortNames:
+    - mtask
+    singular: migrationtask
+  preserveUnknownFields: false
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: MigrationTask represents an migration task
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: Spec i.e. specifications of the MigrationTask
+          properties:
+            cstorPool:
+              description: MigrateCStorPool contains the details of the cstor pool
+                to be migrated
+              properties:
+                rename:
+                  description: If a CSPC with the same name as SPC already exists
+                    then we can rename SPC during migration using Rename
+                  type: string
+                spcName:
+                  description: SPCName contains the name of the storage pool claim
+                    to be migrated
+                  type: string
+              type: object
+            cstorVolume:
+              description: MigrateCStorVolume contains the details of the cstor volume
+                to be migrated
+              properties:
+                pvName:
+                  description: PVName contains the name of the pv associated with
+                    the cstor volume to be migrated
+                  type: string
+              type: object
+          type: object
+        status:
+          description: Status of MigrationTask
+          properties:
+            completedTime:
+              description: CompletedTime of Migrate
+              format: date-time
+              type: string
+            migrationDetailedStatuses:
+              description: MigrationDetailedStatuses contains the list of statuses
+                of each step
+              items:
+                description: MigrationDetailedStatuses represents the latest available
+                  observations of a MigrationTask current state.
+                properties:
+                  lastUpdatedAt:
+                    description: LastUpdatedTime of a MigrateStep
+                    format: date-time
+                    type: string
+                  message:
+                    description: A human-readable message indicating details about
+                      why the migrationStep is in this state
+                    type: string
+                  phase:
+                    description: Phase indicates if the MigrateStep is waiting, errored
+                      or completed.
+                    type: string
+                  reason:
+                    description: Reason is a brief CamelCase string that describes
+                      any failure and is meant for machine parsing and tidy display
+                      in the CLI
+                    type: string
+                  startTime:
+                    description: StartTime of a MigrateStep
+                    format: date-time
+                    type: string
+                  step:
+                    type: string
+                type: object
+              type: array
+            phase:
+              description: Phase indicates if a migrationTask is started, success
+                or errored
+              type: string
+            retries:
+              description: Retries is the number of times the job attempted to migration
+                the resource
+              type: integer
+            startTime:
+              description: StartTime of Migrate
+              format: date-time
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
+  name: upgradetasks.openebs.io
+spec:
+  group: openebs.io
+  names:
+    kind: UpgradeTask
+    listKind: UpgradeTaskList
+    plural: upgradetasks
+    singular: upgradetask
+  preserveUnknownFields: false
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: UpgradeTask represents an upgrade task
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: Spec i.e. specifications of the UpgradeTask
+          properties:
+            cstorPool:
+              description: CStorPool contains the details of the cstor pool to be
+                upgraded
+              properties:
+                options:
+                  description: Options can be used to change the default behaviour
+                    of upgrade
+                  properties:
+                    ignoreStepsOnError:
+                      description: IgnoreStepsOnError allows to ignore steps which
+                        failed
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                poolName:
+                  description: PoolName contains the name of the cstor pool to be
+                    upgraded
+                  type: string
+              type: object
+            cstorPoolCluster:
+              description: CStorPoolCluster contains the details of the storage pool
+                claim to be upgraded
+              properties:
+                cspcName:
+                  description: CSPCName contains the name of the storage pool claim
+                    to be upgraded
+                  type: string
+                options:
+                  description: Options can be used to change the default behaviour
+                    of upgrade
+                  properties:
+                    ignoreStepsOnError:
+                      description: IgnoreStepsOnError allows to ignore steps which
+                        failed
+                      items:
+                        type: string
+                      type: array
+                  type: object
+              type: object
+            cstorPoolInstance:
+              description: CStorPoolInstance contains the details of the cstor pool
+                to be upgraded
+              properties:
+                cspiName:
+                  description: CSPCName contains the name of the storage pool claim
+                    to be upgraded
+                  type: string
+                options:
+                  description: Options can be used to change the default behaviour
+                    of upgrade
+                  properties:
+                    ignoreStepsOnError:
+                      description: IgnoreStepsOnError allows to ignore steps which
+                        failed
+                      items:
+                        type: string
+                      type: array
+                  type: object
+              type: object
+            cstorVolume:
+              description: CStorVolume contains the details of the cstor volume to
+                be upgraded
+              properties:
+                options:
+                  description: Options can be used to change the default behaviour
+                    of upgrade
+                  properties:
+                    ignoreStepsOnError:
+                      description: IgnoreStepsOnError allows to ignore steps which
+                        failed
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                pvName:
+                  description: PVName contains the name of the pv associated with
+                    the cstor volume
+                  type: string
+              type: object
+            fromVersion:
+              description: FromVersion is the current version of the resource.
+              type: string
+            imagePrefix:
+              description: ImagePrefix contains the url prefix of the image url. This
+                field is optional. If not present upgrade takes the previously present
+                ImagePrefix.
+              type: string
+            imageTag:
+              description: ImageTag contains the customized tag for ToVersion if any.
+                This field is optional. If not present upgrade takes the ToVersion
+                as the ImageTag
+              type: string
+            jivaVolume:
+              description: JivaVolume contains the details of the jiva volume to be
+                upgraded
+              properties:
+                options:
+                  description: Options can be used to change the default behaviour
+                    of upgrade
+                  properties:
+                    ignoreStepsOnError:
+                      description: IgnoreStepsOnError allows to ignore steps which
+                        failed
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                pvName:
+                  description: PVName contains the name of the pv associated with
+                    the jiva volume
+                  type: string
+              type: object
+            options:
+              description: Options contains the optional flags that can be passed
+                during upgrade.
+              properties:
+                timeout:
+                  description: Timeout is maximum seconds to wait at any given step
+                    in the upgrade
+                  type: integer
+              type: object
+            storagePoolClaim:
+              description: StoragePoolClaim contains the details of the storage pool
+                claim to be upgraded
+              properties:
+                options:
+                  description: Options can be used to change the default behaviour
+                    of upgrade
+                  properties:
+                    ignoreStepsOnError:
+                      description: IgnoreStepsOnError allows to ignore steps which
+                        failed
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                spcName:
+                  description: SPCName contains the name of the storage pool claim
+                    to be upgraded
+                  type: string
+              type: object
+            toVersion:
+              description: ToVersion is the upgraded version of the resource. It should
+                be same as the version of control plane components version.
+              type: string
+          required:
+          - fromVersion
+          - imagePrefix
+          - imageTag
+          - toVersion
+          type: object
+        status:
+          description: Status of UpgradeTask
+          properties:
+            completedTime:
+              description: CompletedTime of Upgrade
+              format: date-time
+              type: string
+            phase:
+              description: Phase indicates if a upgradeTask is started, success or
+                errored
+              type: string
+            retries:
+              description: Retries is the number of times the job attempted to upgrade
+                the resource
+              type: integer
+            startTime:
+              description: StartTime of Upgrade
+              format: date-time
+              type: string
+            upgradeDetailedStatuses:
+              description: UpgradeDetailedStatuses contains the list of statuses of
+                each step
+              items:
+                description: UpgradeDetailedStatuses represents the latest available
+                  observations of a UpgradeTask current state.
+                properties:
+                  lastUpdatedAt:
+                    description: LastUpdatedTime of a UpgradeStep
+                    format: date-time
+                    type: string
+                  message:
+                    description: A human-readable message indicating details about
+                      why the upgradeStep is in this state
+                    type: string
+                  phase:
+                    description: Phase indicates if the UpgradeStep is waiting, errored
+                      or completed.
+                    type: string
+                  reason:
+                    description: Reason is a brief CamelCase string that describes
+                      any failure and is meant for machine parsing and tidy display
+                      in the CLI
+                    type: string
+                  startTime:
+                    description: StartTime of a UpgradeStep
+                    format: date-time
+                    type: string
+                  step:
+                    description: UpgradeStep is the current step being performed for
+                      a particular resource upgrade
+                    type: string
+                type: object
+              type: array
+          required:
+          - retries
+          type: object
+      required:
+      - spec
+      - status
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/crds/bases/openebs.io_blockdeviceclaims.yaml
+++ b/config/crds/bases/openebs.io_blockdeviceclaims.yaml
@@ -1,0 +1,167 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
+  name: blockdeviceclaims.openebs.io
+spec:
+  group: openebs.io
+  names:
+    kind: BlockDeviceClaim
+    listKind: BlockDeviceClaimList
+    plural: blockdeviceclaims
+    singular: blockdeviceclaim
+  preserveUnknownFields: false
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: BlockDeviceClaim is the Schema for the BlockDeviceClaim CR
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: DeviceClaimSpec defines the request details for a BlockDevice
+          properties:
+            blockDeviceName:
+              description: BlockDeviceName is the reference to the block-device backing
+                this claim
+              type: string
+            blockDeviceNodeAttributes:
+              description: BlockDeviceNodeAttributes is the attributes on the node
+                from which a BD should be selected for this claim. It can include
+                nodename, failure domain etc.
+              properties:
+                hostName:
+                  description: HostName represents the hostname of the Kubernetes
+                    node resource where the BD should be present
+                  type: string
+                nodeName:
+                  description: NodeName represents the name of the Kubernetes node
+                    resource where the BD should be present
+                  type: string
+              type: object
+            deviceClaimDetails:
+              description: Details of the device to be claimed
+              properties:
+                allowPartition:
+                  description: AllowPartition represents whether to claim a full block
+                    device or a device that is a partition
+                  type: boolean
+                blockVolumeMode:
+                  description: 'BlockVolumeMode represents whether to claim a device
+                    in Block mode or Filesystem mode. These are use cases of BlockVolumeMode:
+                    1) Not specified: VolumeMode check will not be effective 2) VolumeModeBlock:
+                    BD should not have any filesystem or mountpoint 3) VolumeModeFileSystem:
+                    BD should have a filesystem and mountpoint. If DeviceFormat is    specified
+                    then the format should match with the FSType in BD'
+                  type: string
+                formatType:
+                  description: Format of the device required, eg:ext4, xfs
+                  type: string
+              type: object
+            deviceType:
+              description: DeviceType represents the type of drive like SSD, HDD etc.,
+              type: string
+            hostName:
+              description: HostName from where blockdevice has to be claimed.
+              type: string
+            resources:
+              description: Resources will help with placing claims on Capacity, IOPS
+              properties:
+                requests:
+                  additionalProperties:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: 'Requests describes the minimum resources required.
+                    eg: if storage resource of 10G is requested minimum capacity of
+                    10G should be available'
+                  type: object
+              required:
+              - requests
+              type: object
+            selector:
+              description: Selector is used to find block devices to be considered
+                for claiming
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                    type: object
+                  type: array
+                matchLabels:
+                  additionalProperties:
+                    type: string
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
+                  type: object
+              type: object
+          required:
+          - deviceType
+          - hostName
+          - resources
+          type: object
+        status:
+          description: DeviceClaimStatus defines the observed state of BlockDeviceClaim
+          properties:
+            phase:
+              description: DeviceClaimPhase is a typed string for phase field of BlockDeviceClaim.
+              type: string
+          required:
+          - phase
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/crds/bases/openebs.io_blockdevices.yaml
+++ b/config/crds/bases/openebs.io_blockdevices.yaml
@@ -1,0 +1,236 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
+  name: blockdevices.openebs.io
+spec:
+  group: openebs.io
+  names:
+    kind: BlockDevice
+    listKind: BlockDeviceList
+    plural: blockdevices
+    singular: blockdevice
+  preserveUnknownFields: false
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: BlockDevice is the Schema used to represent a BlockDevice CR
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: DeviceSpec defines the properties and runtime status of a BlockDevice
+          properties:
+            aggregateDevice:
+              description: AggregateDevice was intended to store the hierachical information
+                in cases of LVM. However this is currently not implemented and may
+                need to be re-looked into for better design. TODO @kmova to be implemented/deprecated
+              type: string
+            capacity:
+              description: Capacity
+              properties:
+                logicalSectorSize:
+                  description: LogicalSectorSize is blockdevice logical-sector size
+                    in bytes
+                  format: int32
+                  type: integer
+                physicalSectorSize:
+                  description: PhysicalSectorSize is blockdevice physical-Sector size
+                    in bytes
+                  format: int32
+                  type: integer
+                storage:
+                  description: Storage is the blockdevice capacity in bytes
+                  format: int64
+                  type: integer
+              required:
+              - logicalSectorSize
+              - physicalSectorSize
+              - storage
+              type: object
+            claimRef:
+              description: Reference to the BDC which has claimed this BD
+              properties:
+                apiVersion:
+                  description: API version of the referent.
+                  type: string
+                fieldPath:
+                  description: 'If referring to a piece of an object instead of an
+                    entire object, this string should contain a valid JSON/Go field
+                    access statement, such as desiredState.manifest.containers[2].
+                    For example, if the object reference is to a container within
+                    a pod, this would take on a value like: "spec.containers{name}"
+                    (where "name" refers to the name of the container that triggered
+                    the event) or if no container name is specified "spec.containers[2]"
+                    (container with index 2 in this pod). This syntax is chosen only
+                    to have some well-defined way of referencing a part of an object.
+                    TODO: this design is not final and this field is subject to change
+                    in the future.'
+                  type: string
+                kind:
+                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+                resourceVersion:
+                  description: 'Specific resourceVersion to which this reference is
+                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                  type: string
+                uid:
+                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                  type: string
+              type: object
+            details:
+              description: Details contain static attributes of BD like model,serial,
+                and so forth
+              properties:
+                compliance:
+                  description: Compliance is standards/specifications version implmented
+                    by device firmware  such as SPC-1, SPC-2, etc
+                  type: string
+                deviceType:
+                  description: DeviceType represents the type of device like sparse,
+                    disk, partition, lvm, raid
+                  type: string
+                driveType:
+                  description: DriveType is the type of backing drive, HDD/SSD
+                  type: string
+                firmwareRevision:
+                  description: disk firmware revision
+                  type: string
+                hardwareSectorSize:
+                  description: HardwareSectorSize is the hardware sector size in bytes
+                  format: int32
+                  type: integer
+                logicalBlockSize:
+                  description: LogicalBlockSize is the logical block size in bytes
+                    reported by /sys/class/block/sda/queue/logical_block_size
+                  format: int32
+                  type: integer
+                model:
+                  description: Model is model of disk
+                  type: string
+                physicalBlockSize:
+                  description: PhysicalBlockSize is the physical block size in bytes
+                    reported by /sys/class/block/sda/queue/physical_block_size
+                  format: int32
+                  type: integer
+                serial:
+                  description: Serial is serial number of disk
+                  type: string
+                vendor:
+                  description: Vendor is vendor of disk
+                  type: string
+              required:
+              - compliance
+              - deviceType
+              - driveType
+              - firmwareRevision
+              - hardwareSectorSize
+              - logicalBlockSize
+              - model
+              - physicalBlockSize
+              - serial
+              - vendor
+              type: object
+            devlinks:
+              description: DevLinks contains soft links of a block device like /dev/by-id/...
+                /dev/by-uuid/...
+              items:
+                description: DeviceDevLink holds the maping between type and links
+                  like by-id type or by-path type link
+                properties:
+                  kind:
+                    description: Kind is the type of link like by-id or by-path.
+                    type: string
+                  links:
+                    description: Links are the soft links of Type type
+                    items:
+                      type: string
+                    type: array
+                type: object
+              type: array
+            filesystem:
+              description: FileSystem contains mountpoint and filesystem type
+              properties:
+                fsType:
+                  description: Type represents the FileSystem type of the block device
+                  type: string
+                mountPoint:
+                  description: MountPoint represents the mountpoint of the block device.
+                  type: string
+              type: object
+            nodeAttributes:
+              description: NodeAttributes has the details of the node on which BD
+                is attached
+              properties:
+                nodeName:
+                  description: NodeName is the name of the Kubernetes node resource
+                    on which the device is attached
+                  type: string
+              required:
+              - nodeName
+              type: object
+            parentDevice:
+              description: "ParentDevice was intented to store the UUID of the parent
+                Block Device as is the case for partitioned block devices. \n For
+                example: /dev/sda is the parent for /dev/sdap1 TODO @kmova to be implemented/deprecated"
+              type: string
+            partitioned:
+              description: Partitioned represents if BlockDevice has partions or not
+                (YES/NO) Currently always default to NO. TODO @kmova to be implemented/deprecated
+              type: string
+            path:
+              description: Path contain devpath (e.g. /dev/sdb)
+              type: string
+          required:
+          - capacity
+          - details
+          - devlinks
+          - nodeAttributes
+          - partitioned
+          - path
+          type: object
+        status:
+          description: DeviceStatus defines the observed state of BlockDevice
+          properties:
+            claimState:
+              description: claim state of the block device
+              type: string
+            state:
+              description: State is the current state of the blockdevice (Active/Inactive)
+              type: string
+          required:
+          - claimState
+          - state
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/crds/bases/openebs.io_cstorbackups.yaml
+++ b/config/crds/bases/openebs.io_cstorbackups.yaml
@@ -1,0 +1,83 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
+  name: cstorbackups.openebs.io
+spec:
+  group: openebs.io
+  names:
+    kind: CStorBackup
+    listKind: CStorBackupList
+    plural: cstorbackups
+    singular: cstorbackup
+  preserveUnknownFields: false
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: CStorBackup describes a cstor backup resource created as a custom
+        resource
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: CStorBackupSpec is the spec for a CStorBackup resource
+          properties:
+            backupDest:
+              description: BackupDest is the remote address for backup transfer
+              type: string
+            backupName:
+              description: BackupName is a name of the backup or scheduled backup
+              type: string
+            localSnap:
+              description: LocalSnap is flag to enable local snapshot only
+              type: boolean
+            prevSnapName:
+              description: PrevSnapName is the last completed-backup's snapshot name
+              type: string
+            snapName:
+              description: SnapName is a name of the current backup snapshot
+              type: string
+            volumeName:
+              description: VolumeName is a name of the volume for which this backup
+                is destined
+              type: string
+          required:
+          - backupDest
+          - backupName
+          - localSnap
+          - prevSnapName
+          - snapName
+          - volumeName
+          type: object
+        status:
+          description: CStorBackupStatus is to hold status of backup
+          type: string
+      required:
+      - spec
+      - status
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/crds/bases/openebs.io_cstorcompletedbackups.yaml
+++ b/config/crds/bases/openebs.io_cstorcompletedbackups.yaml
@@ -1,0 +1,79 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
+  name: cstorcompletedbackups.openebs.io
+spec:
+  group: openebs.io
+  names:
+    kind: CStorCompletedBackup
+    listKind: CStorCompletedBackupList
+    plural: cstorcompletedbackups
+    singular: cstorcompletedbackup
+  preserveUnknownFields: false
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: CStorCompletedBackup describes a cstor completed-backup resource
+        created as custom resource
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: CStorBackupSpec is the spec for a CStorBackup resource
+          properties:
+            backupDest:
+              description: BackupDest is the remote address for backup transfer
+              type: string
+            backupName:
+              description: BackupName is a name of the backup or scheduled backup
+              type: string
+            localSnap:
+              description: LocalSnap is flag to enable local snapshot only
+              type: boolean
+            prevSnapName:
+              description: PrevSnapName is the last completed-backup's snapshot name
+              type: string
+            snapName:
+              description: SnapName is a name of the current backup snapshot
+              type: string
+            volumeName:
+              description: VolumeName is a name of the volume for which this backup
+                is destined
+              type: string
+          required:
+          - backupDest
+          - backupName
+          - localSnap
+          - prevSnapName
+          - snapName
+          - volumeName
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/crds/bases/openebs.io_cstorrestores.yaml
+++ b/config/crds/bases/openebs.io_cstorrestores.yaml
@@ -1,0 +1,83 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
+  name: cstorrestores.openebs.io
+spec:
+  group: openebs.io
+  names:
+    kind: CStorRestore
+    listKind: CStorRestoreList
+    plural: cstorrestores
+    singular: cstorrestore
+  preserveUnknownFields: false
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: CStorRestore describes a cstor restore resource created as a custom
+        resource
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: CStorRestoreSpec is the spec for a CStorRestore resource
+          properties:
+            localRestore:
+              type: boolean
+            maxretrycount:
+              type: integer
+            restoreName:
+              type: string
+            restoreSrc:
+              type: string
+            retrycount:
+              type: integer
+            size:
+              anyOf:
+              - type: integer
+              - type: string
+              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+              x-kubernetes-int-or-string: true
+            storageClass:
+              type: string
+            volumeName:
+              type: string
+          required:
+          - maxretrycount
+          - restoreName
+          - restoreSrc
+          - retrycount
+          - volumeName
+          type: object
+        status:
+          description: CStorRestoreStatus is to hold result of action.
+          type: string
+      required:
+      - spec
+      - status
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/crds/bases/openebs.io_migrationtasks.yaml
+++ b/config/crds/bases/openebs.io_migrationtasks.yaml
@@ -1,0 +1,128 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
+  name: migrationtasks.openebs.io
+spec:
+  group: openebs.io
+  names:
+    kind: MigrationTask
+    listKind: MigrationTaskList
+    plural: migrationtasks
+    shortNames:
+    - mtask
+    singular: migrationtask
+  preserveUnknownFields: false
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: MigrationTask represents an migration task
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: Spec i.e. specifications of the MigrationTask
+          properties:
+            cstorPool:
+              description: MigrateCStorPool contains the details of the cstor pool
+                to be migrated
+              properties:
+                rename:
+                  description: If a CSPC with the same name as SPC already exists
+                    then we can rename SPC during migration using Rename
+                  type: string
+                spcName:
+                  description: SPCName contains the name of the storage pool claim
+                    to be migrated
+                  type: string
+              type: object
+            cstorVolume:
+              description: MigrateCStorVolume contains the details of the cstor volume
+                to be migrated
+              properties:
+                pvName:
+                  description: PVName contains the name of the pv associated with
+                    the cstor volume to be migrated
+                  type: string
+              type: object
+          type: object
+        status:
+          description: Status of MigrationTask
+          properties:
+            completedTime:
+              description: CompletedTime of Migrate
+              format: date-time
+              type: string
+            migrationDetailedStatuses:
+              description: MigrationDetailedStatuses contains the list of statuses
+                of each step
+              items:
+                description: MigrationDetailedStatuses represents the latest available
+                  observations of a MigrationTask current state.
+                properties:
+                  lastUpdatedAt:
+                    description: LastUpdatedTime of a MigrateStep
+                    format: date-time
+                    type: string
+                  message:
+                    description: A human-readable message indicating details about
+                      why the migrationStep is in this state
+                    type: string
+                  phase:
+                    description: Phase indicates if the MigrateStep is waiting, errored
+                      or completed.
+                    type: string
+                  reason:
+                    description: Reason is a brief CamelCase string that describes
+                      any failure and is meant for machine parsing and tidy display
+                      in the CLI
+                    type: string
+                  startTime:
+                    description: StartTime of a MigrateStep
+                    format: date-time
+                    type: string
+                  step:
+                    type: string
+                type: object
+              type: array
+            phase:
+              description: Phase indicates if a migrationTask is started, success
+                or errored
+              type: string
+            retries:
+              description: Retries is the number of times the job attempted to migration
+                the resource
+              type: integer
+            startTime:
+              description: StartTime of Migrate
+              format: date-time
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/crds/bases/openebs.io_upgradetasks.yaml
+++ b/config/crds/bases/openebs.io_upgradetasks.yaml
@@ -1,0 +1,260 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
+  name: upgradetasks.openebs.io
+spec:
+  group: openebs.io
+  names:
+    kind: UpgradeTask
+    listKind: UpgradeTaskList
+    plural: upgradetasks
+    singular: upgradetask
+  preserveUnknownFields: false
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: UpgradeTask represents an upgrade task
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: Spec i.e. specifications of the UpgradeTask
+          properties:
+            cstorPool:
+              description: CStorPool contains the details of the cstor pool to be
+                upgraded
+              properties:
+                options:
+                  description: Options can be used to change the default behaviour
+                    of upgrade
+                  properties:
+                    ignoreStepsOnError:
+                      description: IgnoreStepsOnError allows to ignore steps which
+                        failed
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                poolName:
+                  description: PoolName contains the name of the cstor pool to be
+                    upgraded
+                  type: string
+              type: object
+            cstorPoolCluster:
+              description: CStorPoolCluster contains the details of the storage pool
+                claim to be upgraded
+              properties:
+                cspcName:
+                  description: CSPCName contains the name of the storage pool claim
+                    to be upgraded
+                  type: string
+                options:
+                  description: Options can be used to change the default behaviour
+                    of upgrade
+                  properties:
+                    ignoreStepsOnError:
+                      description: IgnoreStepsOnError allows to ignore steps which
+                        failed
+                      items:
+                        type: string
+                      type: array
+                  type: object
+              type: object
+            cstorPoolInstance:
+              description: CStorPoolInstance contains the details of the cstor pool
+                to be upgraded
+              properties:
+                cspiName:
+                  description: CSPCName contains the name of the storage pool claim
+                    to be upgraded
+                  type: string
+                options:
+                  description: Options can be used to change the default behaviour
+                    of upgrade
+                  properties:
+                    ignoreStepsOnError:
+                      description: IgnoreStepsOnError allows to ignore steps which
+                        failed
+                      items:
+                        type: string
+                      type: array
+                  type: object
+              type: object
+            cstorVolume:
+              description: CStorVolume contains the details of the cstor volume to
+                be upgraded
+              properties:
+                options:
+                  description: Options can be used to change the default behaviour
+                    of upgrade
+                  properties:
+                    ignoreStepsOnError:
+                      description: IgnoreStepsOnError allows to ignore steps which
+                        failed
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                pvName:
+                  description: PVName contains the name of the pv associated with
+                    the cstor volume
+                  type: string
+              type: object
+            fromVersion:
+              description: FromVersion is the current version of the resource.
+              type: string
+            imagePrefix:
+              description: ImagePrefix contains the url prefix of the image url. This
+                field is optional. If not present upgrade takes the previously present
+                ImagePrefix.
+              type: string
+            imageTag:
+              description: ImageTag contains the customized tag for ToVersion if any.
+                This field is optional. If not present upgrade takes the ToVersion
+                as the ImageTag
+              type: string
+            jivaVolume:
+              description: JivaVolume contains the details of the jiva volume to be
+                upgraded
+              properties:
+                options:
+                  description: Options can be used to change the default behaviour
+                    of upgrade
+                  properties:
+                    ignoreStepsOnError:
+                      description: IgnoreStepsOnError allows to ignore steps which
+                        failed
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                pvName:
+                  description: PVName contains the name of the pv associated with
+                    the jiva volume
+                  type: string
+              type: object
+            options:
+              description: Options contains the optional flags that can be passed
+                during upgrade.
+              properties:
+                timeout:
+                  description: Timeout is maximum seconds to wait at any given step
+                    in the upgrade
+                  type: integer
+              type: object
+            storagePoolClaim:
+              description: StoragePoolClaim contains the details of the storage pool
+                claim to be upgraded
+              properties:
+                options:
+                  description: Options can be used to change the default behaviour
+                    of upgrade
+                  properties:
+                    ignoreStepsOnError:
+                      description: IgnoreStepsOnError allows to ignore steps which
+                        failed
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                spcName:
+                  description: SPCName contains the name of the storage pool claim
+                    to be upgraded
+                  type: string
+              type: object
+            toVersion:
+              description: ToVersion is the upgraded version of the resource. It should
+                be same as the version of control plane components version.
+              type: string
+          required:
+          - fromVersion
+          - imagePrefix
+          - imageTag
+          - toVersion
+          type: object
+        status:
+          description: Status of UpgradeTask
+          properties:
+            completedTime:
+              description: CompletedTime of Upgrade
+              format: date-time
+              type: string
+            phase:
+              description: Phase indicates if a upgradeTask is started, success or
+                errored
+              type: string
+            retries:
+              description: Retries is the number of times the job attempted to upgrade
+                the resource
+              type: integer
+            startTime:
+              description: StartTime of Upgrade
+              format: date-time
+              type: string
+            upgradeDetailedStatuses:
+              description: UpgradeDetailedStatuses contains the list of statuses of
+                each step
+              items:
+                description: UpgradeDetailedStatuses represents the latest available
+                  observations of a UpgradeTask current state.
+                properties:
+                  lastUpdatedAt:
+                    description: LastUpdatedTime of a UpgradeStep
+                    format: date-time
+                    type: string
+                  message:
+                    description: A human-readable message indicating details about
+                      why the upgradeStep is in this state
+                    type: string
+                  phase:
+                    description: Phase indicates if the UpgradeStep is waiting, errored
+                      or completed.
+                    type: string
+                  reason:
+                    description: Reason is a brief CamelCase string that describes
+                      any failure and is meant for machine parsing and tidy display
+                      in the CLI
+                    type: string
+                  startTime:
+                    description: StartTime of a UpgradeStep
+                    format: date-time
+                    type: string
+                  step:
+                    description: UpgradeStep is the current step being performed for
+                      a particular resource upgrade
+                    type: string
+                type: object
+              type: array
+          required:
+          - retries
+          type: object
+      required:
+      - spec
+      - status
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []


### PR DESCRIPTION
Right now, the CRDs are only in Go code which makes it hard to apply manually for users. Having one place for all OpenEBS CRD resources might make sense in general, and also acts as workaround until the Helm chart can deploy the CRDs directly instead of requiring the software to run first (explained in https://github.com/openebs/openebs/issues/3052).