### PR TITLE
refact(crds): update crds to use apiextensions.k8s.io/v1 apis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ GOBIN := $(or $(shell go env GOBIN 2>/dev/null), $(shell go env GOPATH 2>/dev/nu
 
 # find or download controller-gen
 controller-gen:
-ifneq ($(shell controller-gen --version 2> /dev/null), Version: v0.3.0)
-	@(cd /tmp; GO111MODULE=on go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.3.0)
+ifneq ($(shell controller-gen --version 2> /dev/null), Version: v0.4.0)
+	@(cd /tmp; GO111MODULE=on go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.0)
 CONTROLLER_GEN=$(GOBIN)/controller-gen
 else
 CONTROLLER_GEN=$(shell which controller-gen)
@@ -30,7 +30,7 @@ generate: generate-crds
 
 generate-crds: controller-gen
 	# Generate manifests e.g. CRD, RBAC etc.
-	$(CONTROLLER_GEN) crd:crdVersions=v1,trivialVersions=true,preserveUnknownFields=false paths="./pkg/apis/cstor/..." output:crd:artifacts:config=config/crds/bases
+	$(CONTROLLER_GEN) crd:trivialVersions=true,preserveUnknownFields=false paths="./pkg/apis/cstor/..." output:crd:artifacts:config=config/crds/bases
 	# merge all crds into a single file
 	rm $(ALL_CRDS)
 	cat config/crds/bases/*.yaml >> $(ALL_CRDS)

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ GOBIN := $(or $(shell go env GOBIN 2>/dev/null), $(shell go env GOPATH 2>/dev/nu
 
 # find or download controller-gen
 controller-gen:
-ifneq ($(shell controller-gen --version 2> /dev/null), Version: v0.2.9)
-	@(cd /tmp; GO111MODULE=on go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.9)
+ifneq ($(shell controller-gen --version 2> /dev/null), Version: v0.3.0)
+	@(cd /tmp; GO111MODULE=on go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.3.0)
 CONTROLLER_GEN=$(GOBIN)/controller-gen
 else
 CONTROLLER_GEN=$(shell which controller-gen)
@@ -30,7 +30,7 @@ generate: generate-crds
 
 generate-crds: controller-gen
 	# Generate manifests e.g. CRD, RBAC etc.
-	$(CONTROLLER_GEN) crd:trivialVersions=true,preserveUnknownFields=false paths="./pkg/apis/cstor/..." output:crd:artifacts:config=config/crds/bases
+	$(CONTROLLER_GEN) crd:crdVersions=v1,trivialVersions=true,preserveUnknownFields=false paths="./pkg/apis/cstor/..." output:crd:artifacts:config=config/crds/bases
 	# merge all crds into a single file
 	rm $(ALL_CRDS)
 	cat config/crds/bases/*.yaml >> $(ALL_CRDS)

--- a/config/crds/all-crds.yaml
+++ b/config/crds/all-crds.yaml
@@ -1,26 +1,13 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.9
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: cstorbackups.cstor.openebs.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.volumeName
-    description: Name of the volume for which this backup is destined
-    name: Volume
-    type: string
-  - JSONPath: .spec.backupName
-    description: Name of the backup or scheduled backup
-    name: Backup/Schedule
-    type: string
-  - JSONPath: .status
-    description: Identifies the phase of the backup
-    name: Status
-    type: string
   group: cstor.openebs.io
   names:
     kind: CStorBackup
@@ -29,65 +16,77 @@ spec:
     shortNames:
     - cbackup
     singular: cstorbackup
-  preserveUnknownFields: false
   scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: CStorBackup describes a cstor backup resource created as a custom
-        resource
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: CStorBackupSpec is the spec for a CStorBackup resource
-          properties:
-            backupDest:
-              description: BackupDest is the remote address for backup transfer
-              type: string
-            backupName:
-              description: BackupName is the name of the backup or scheduled backup
-              type: string
-            localSnap:
-              description: LocalSnap is the flag to enable local snapshot only
-              type: boolean
-            prevSnapName:
-              description: PrevSnapName is the last completed-backup's snapshot name
-              type: string
-            snapName:
-              description: SnapName is the name of the current backup snapshot
-              type: string
-            volumeName:
-              description: VolumeName is the name of the volume for which this backup
-                is destined
-              type: string
-          required:
-          - backupName
-          - snapName
-          - volumeName
-          type: object
-        status:
-          description: CStorBackupStatus is a string type that represents the status
-            of the backup
-          type: string
-      required:
-      - spec
-      type: object
-  version: v1
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: Name of the volume for which this backup is destined
+      jsonPath: .spec.volumeName
+      name: Volume
+      type: string
+    - description: Name of the backup or scheduled backup
+      jsonPath: .spec.backupName
+      name: Backup/Schedule
+      type: string
+    - description: Identifies the phase of the backup
+      jsonPath: .status
+      name: Status
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: CStorBackup describes a cstor backup resource created as a custom
+          resource
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CStorBackupSpec is the spec for a CStorBackup resource
+            properties:
+              backupDest:
+                description: BackupDest is the remote address for backup transfer
+                type: string
+              backupName:
+                description: BackupName is the name of the backup or scheduled backup
+                type: string
+              localSnap:
+                description: LocalSnap is the flag to enable local snapshot only
+                type: boolean
+              prevSnapName:
+                description: PrevSnapName is the last completed-backup's snapshot
+                  name
+                type: string
+              snapName:
+                description: SnapName is the name of the current backup snapshot
+                type: string
+              volumeName:
+                description: VolumeName is the name of the volume for which this backup
+                  is destined
+                type: string
+            required:
+            - backupName
+            - snapName
+            - volumeName
+            type: object
+          status:
+            description: CStorBackupStatus is a string type that represents the status
+              of the backup
+            type: string
+        required:
+        - spec
+        type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""
@@ -96,27 +95,14 @@ status:
   storedVersions: []
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.9
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: cstorcompletedbackups.cstor.openebs.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.volumeName
-    description: Volume name on which backup is performed
-    name: Volume
-    type: string
-  - JSONPath: .spec.backupName
-    description: Name of the backup or scheduled backup
-    name: Backup/Schedule
-    type: string
-  - JSONPath: .spec.lastSnapName
-    description: Last successfully backup snapshot
-    name: LastSnap
-    type: string
   group: cstor.openebs.io
   names:
     kind: CStorCompletedBackup
@@ -125,53 +111,64 @@ spec:
     shortNames:
     - ccompletedbackup
     singular: cstorcompletedbackup
-  preserveUnknownFields: false
   scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: CStorCompletedBackup describes a cstor completed-backup resource
-        created as custom resource
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: CStorCompletedBackupSpec is the spec for a CStorBackup resource
-          properties:
-            backupName:
-              description: BackupName is the name of backup or scheduled backup
-              type: string
-            lastSnapName:
-              description: LastSnapName is the name of last completed-backup's snapshot
-                name
-              type: string
-            secondLastSnapName:
-              description: SecondLastSnapName is the name of second last 'successfully'
-                completed-backup's snapshot
-              type: string
-            volumeName:
-              description: VolumeName is the name of volume for which this backup
-                is destined
-              type: string
-          type: object
-      required:
-      - spec
-      type: object
-  version: v1
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: Volume name on which backup is performed
+      jsonPath: .spec.volumeName
+      name: Volume
+      type: string
+    - description: Name of the backup or scheduled backup
+      jsonPath: .spec.backupName
+      name: Backup/Schedule
+      type: string
+    - description: Last successfully backup snapshot
+      jsonPath: .spec.lastSnapName
+      name: LastSnap
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: CStorCompletedBackup describes a cstor completed-backup resource
+          created as custom resource
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CStorCompletedBackupSpec is the spec for a CStorBackup resource
+            properties:
+              backupName:
+                description: BackupName is the name of backup or scheduled backup
+                type: string
+              lastSnapName:
+                description: LastSnapName is the name of last completed-backup's snapshot
+                  name
+                type: string
+              secondLastSnapName:
+                description: SecondLastSnapName is the name of second last 'successfully'
+                  completed-backup's snapshot
+                type: string
+              volumeName:
+                description: VolumeName is the name of volume for which this backup
+                  is destined
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""
@@ -180,31 +177,14 @@ status:
   storedVersions: []
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.9
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: cstorpoolclusters.cstor.openebs.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.healthyInstances
-    description: The number of healthy cStorPoolInstances
-    name: HealthyInstances
-    type: integer
-  - JSONPath: .status.provisionedInstances
-    description: The number of provisioned cStorPoolInstances
-    name: ProvisionedInstances
-    type: integer
-  - JSONPath: .status.desiredInstances
-    description: The number of desired cStorPoolInstances
-    name: DesiredInstances
-    type: integer
-  - JSONPath: .metadata.creationTimestamp
-    description: Age of CStorPoolCluster
-    name: Age
-    type: date
   group: cstor.openebs.io
   names:
     kind: CStorPoolCluster
@@ -213,110 +193,1422 @@ spec:
     shortNames:
     - cspc
     singular: cstorpoolcluster
-  preserveUnknownFields: false
   scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: CStorPoolCluster describes a CStorPoolCluster custom resource.
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: CStorPoolClusterSpec is the spec for a CStorPoolClusterSpec
-            resource
-          properties:
-            auxResources:
-              description: AuxResources are the compute resources required by the
-                cstor-pool pod side car containers.
-              nullable: true
-              properties:
-                limits:
-                  additionalProperties:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  description: 'Limits describes the maximum amount of compute resources
-                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                  type: object
-                requests:
-                  additionalProperties:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  description: 'Requests describes the minimum amount of compute resources
-                    required. If Requests is omitted for a container, it defaults
-                    to Limits if that is explicitly specified, otherwise to an implementation-defined
-                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                  type: object
-              type: object
-            pools:
-              description: Pools is the spec for pools for various nodes where it
-                should be created.
-              items:
-                description: PoolSpec is the spec for pool on node where it should
-                  be created.
+  versions:
+  - additionalPrinterColumns:
+    - description: The number of healthy cStorPoolInstances
+      jsonPath: .status.healthyInstances
+      name: HealthyInstances
+      type: integer
+    - description: The number of provisioned cStorPoolInstances
+      jsonPath: .status.provisionedInstances
+      name: ProvisionedInstances
+      type: integer
+    - description: The number of desired cStorPoolInstances
+      jsonPath: .status.desiredInstances
+      name: DesiredInstances
+      type: integer
+    - description: Age of CStorPoolCluster
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: CStorPoolCluster describes a CStorPoolCluster custom resource.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CStorPoolClusterSpec is the spec for a CStorPoolClusterSpec
+              resource
+            properties:
+              auxResources:
+                description: AuxResources are the compute resources required by the
+                  cstor-pool pod side car containers.
+                nullable: true
                 properties:
-                  dataRaidGroups:
-                    description: DataRaidGroups is the raid group configuration for
-                      the given pool.
-                    items:
-                      description: RaidGroup contains the details of a raid group
-                        for the pool
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                type: object
+              pools:
+                description: Pools is the spec for pools for various nodes where it
+                  should be created.
+                items:
+                  description: PoolSpec is the spec for pool on node where it should
+                    be created.
+                  properties:
+                    dataRaidGroups:
+                      description: DataRaidGroups is the raid group configuration
+                        for the given pool.
+                      items:
+                        description: RaidGroup contains the details of a raid group
+                          for the pool
+                        properties:
+                          blockDevices:
+                            items:
+                              description: CStorPoolInstanceBlockDevice contains the
+                                details of block devices that constitutes a raid group.
+                              properties:
+                                blockDeviceName:
+                                  description: BlockDeviceName is the name of the
+                                    block device.
+                                  type: string
+                                capacity:
+                                  description: Capacity is the capacity of the block
+                                    device. It is system generated
+                                  format: int64
+                                  type: integer
+                                devLink:
+                                  description: DevLink is the dev link for block devices
+                                  type: string
+                              required:
+                              - blockDeviceName
+                              type: object
+                            type: array
+                        required:
+                        - blockDevices
+                        type: object
+                      type: array
+                    nodeSelector:
+                      additionalProperties:
+                        type: string
+                      description: NodeSelector is the labels that will be used to
+                        select a node for pool provisioning. Required field
+                      type: object
+                    poolConfig:
+                      description: PoolConfig is the default pool config that applies
+                        to the pool on node.
                       properties:
-                        blockDevices:
+                        auxResources:
+                          description: AuxResources are the compute resources required
+                            by the cstor-pool pod side car containers.
+                          nullable: true
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        compression:
+                          description: 'Compression to enable compression Optional
+                            -- defaults to off Possible values : lz, off'
+                          type: string
+                        dataRaidGroupType:
+                          description: DataRaidGroupType is the  raid type.
+                          type: string
+                        priorityClassName:
+                          description: PriorityClassName if specified applies to this
+                            pool pod If left empty, DefaultPriorityClassName is applied.
+                            (See CStorPoolClusterSpec.DefaultPriorityClassName) If
+                            both are empty, not priority class is applied.
+                          nullable: true
+                          type: string
+                        resources:
+                          description: Resources are the compute resources required
+                            by the cstor-pool container.
+                          nullable: true
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        roThresholdLimit:
+                          description: 'ROThresholdLimit is threshold(percentage base)
+                            limit for pool read only mode. If ROThresholdLimit(%)
+                            amount of pool storage is reached then pool will set to
+                            readonly. NOTE: 1. If ROThresholdLimit is set to 100 then
+                            entire    pool storage will be used by default it will
+                            be set to 85%. 2. ROThresholdLimit value will be 0 <=
+                            ROThresholdLimit <= 100.'
+                          nullable: true
+                          type: integer
+                        thickProvision:
+                          description: ThickProvision to enable thick provisioning
+                            Optional -- defaults to false
+                          type: boolean
+                        tolerations:
+                          description: Tolerations, if specified, the pool pod's tolerations.
                           items:
-                            description: CStorPoolInstanceBlockDevice contains the
-                              details of block devices that constitutes a raid group.
+                            description: The pod this Toleration is attached to tolerates
+                              any taint that matches the triple <key,value,effect>
+                              using the matching operator <operator>.
                             properties:
-                              blockDeviceName:
-                                description: BlockDeviceName is the name of the block
-                                  device.
+                              effect:
+                                description: Effect indicates the taint effect to
+                                  match. Empty means match all taint effects. When
+                                  specified, allowed values are NoSchedule, PreferNoSchedule
+                                  and NoExecute.
                                 type: string
-                              capacity:
-                                description: Capacity is the capacity of the block
-                                  device. It is system generated
+                              key:
+                                description: Key is the taint key that the toleration
+                                  applies to. Empty means match all taint keys. If
+                                  the key is empty, operator must be Exists; this
+                                  combination means to match all values and all keys.
+                                type: string
+                              operator:
+                                description: Operator represents a key's relationship
+                                  to the value. Valid operators are Exists and Equal.
+                                  Defaults to Equal. Exists is equivalent to wildcard
+                                  for value, so that a pod can tolerate all taints
+                                  of a particular category.
+                                type: string
+                              tolerationSeconds:
+                                description: TolerationSeconds represents the period
+                                  of time the toleration (which must be of effect
+                                  NoExecute, otherwise this field is ignored) tolerates
+                                  the taint. By default, it is not set, which means
+                                  tolerate the taint forever (do not evict). Zero
+                                  and negative values will be treated as 0 (evict
+                                  immediately) by the system.
                                 format: int64
                                 type: integer
-                              devLink:
-                                description: DevLink is the dev link for block devices
+                              value:
+                                description: Value is the taint value the toleration
+                                  matches to. If the operator is Exists, the value
+                                  should be empty, otherwise just a regular string.
                                 type: string
-                            required:
-                            - blockDeviceName
                             type: object
+                          nullable: true
                           type: array
+                        writeCacheGroupType:
+                          description: WriteCacheGroupType is the write cache raid
+                            type.
+                          type: string
                       required:
-                      - blockDevices
+                      - dataRaidGroupType
+                      type: object
+                    writeCacheRaidGroups:
+                      description: WriteCacheRaidGroups is the write cache raid group.
+                      items:
+                        description: RaidGroup contains the details of a raid group
+                          for the pool
+                        properties:
+                          blockDevices:
+                            items:
+                              description: CStorPoolInstanceBlockDevice contains the
+                                details of block devices that constitutes a raid group.
+                              properties:
+                                blockDeviceName:
+                                  description: BlockDeviceName is the name of the
+                                    block device.
+                                  type: string
+                                capacity:
+                                  description: Capacity is the capacity of the block
+                                    device. It is system generated
+                                  format: int64
+                                  type: integer
+                                devLink:
+                                  description: DevLink is the dev link for block devices
+                                  type: string
+                              required:
+                              - blockDeviceName
+                              type: object
+                            type: array
+                        required:
+                        - blockDevices
+                        type: object
+                      nullable: true
+                      type: array
+                  required:
+                  - dataRaidGroups
+                  - nodeSelector
+                  type: object
+                type: array
+              priorityClassName:
+                description: DefaultPriorityClassName if specified applies to all
+                  the pool pods in the pool spec if the priorityClass at the pool
+                  level is not specified.
+                type: string
+              resources:
+                description: DefaultResources are the compute resources required by
+                  the cstor-pool container. If the resources at PoolConfig is not
+                  specified, this is written to CSPI PoolConfig.
+                nullable: true
+                properties:
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                type: object
+              tolerations:
+                description: Tolerations, if specified, are the pool pod's tolerations
+                  If tolerations at PoolConfig is empty, this is written to CSPI PoolConfig.
+                items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
+                  properties:
+                    effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
+                      type: string
+                  type: object
+                nullable: true
+                type: array
+            type: object
+          status:
+            description: CStorPoolClusterStatus represents the latest available observations
+              of a CSPC's current state.
+            properties:
+              conditions:
+                description: Current state of CSPC.
+                items:
+                  description: CStorPoolClusterCondition describes the state of a
+                    CSPC at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    lastUpdateTime:
+                      description: The last time this condition was updated.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of CSPC condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                nullable: true
+                type: array
+              desiredInstances:
+                description: DesiredInstances is the number of CSPI(s) that should
+                  be provisioned.
+                format: int32
+                nullable: true
+                type: integer
+              healthyInstances:
+                description: HealthyInstances is the number of CSPI(s) that are healthy.
+                format: int32
+                nullable: true
+                type: integer
+              provisionedInstances:
+                description: ProvisionedInstances is the the number of CSPI present
+                  at the current state.
+                format: int32
+                nullable: true
+                type: integer
+            type: object
+          versionDetails:
+            description: VersionDetails provides the details for upgrade
+            properties:
+              autoUpgrade:
+                description: If AutoUpgrade is set to true then the resource is upgraded
+                  automatically without any manual steps
+                type: boolean
+              desired:
+                description: Desired is the version that we want to upgrade or the
+                  control plane version
+                type: string
+              status:
+                description: Status gives the status of reconciliation triggered when
+                  the desired and current version are not same
+                properties:
+                  current:
+                    description: Current is the version of resource
+                    type: string
+                  dependentsUpgraded:
+                    description: DependentsUpgraded gives the details whether all
+                      children of a resource are upgraded to desired version or not
+                    type: boolean
+                  lastUpdateTime:
+                    description: LastUpdateTime is the time the status was last  updated
+                    format: date-time
+                    nullable: true
+                    type: string
+                  message:
+                    description: Message is a human readable message if some error
+                      occurs
+                    type: string
+                  reason:
+                    description: Reason is the actual reason for the error state
+                    type: string
+                  state:
+                    description: State is the state of reconciliation
+                    type: string
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  name: cstorpoolinstances.cstor.openebs.io
+spec:
+  group: cstor.openebs.io
+  names:
+    kind: CStorPoolInstance
+    listKind: CStorPoolInstanceList
+    plural: cstorpoolinstances
+    shortNames:
+    - cspi
+    singular: cstorpoolinstance
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Host name where cstorpool instances scheduled
+      jsonPath: .spec.hostName
+      name: HostName
+      type: string
+    - description: The amount of storage space within the pool that has been physically
+        allocated
+      jsonPath: .status.capacity.used
+      name: Allocated
+      priority: 1
+      type: string
+    - description: The amount of usable free space available in the pool
+      jsonPath: .status.capacity.free
+      name: Free
+      type: string
+    - description: Total amount of usable space in pool
+      jsonPath: .status.capacity.total
+      name: Capacity
+      type: string
+    - description: Identifies the pool read only mode
+      jsonPath: .status.readOnly
+      name: ReadOnly
+      type: boolean
+    - description: Represents no.of replicas present in the pool
+      jsonPath: .status.provisionedReplicas
+      name: ProvisionedReplicas
+      type: integer
+    - description: Represents no.of healthy replicas present in the pool
+      jsonPath: .status.healthyReplicas
+      name: HealthyReplicas
+      type: integer
+    - description: Represents the type of the storage pool
+      jsonPath: .spec.poolConfig.dataRaidGroupType
+      name: Type
+      priority: 1
+      type: string
+    - description: Identifies the current health of the pool
+      jsonPath: .status.phase
+      name: Status
+      type: string
+    - description: Age of CStorPoolInstance
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: CStorPoolInstance describes a cstor pool instance resource.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec is the specification of the cstorpoolinstance resource.
+            properties:
+              dataRaidGroups:
+                description: DataRaidGroups is the raid group configuration for the
+                  given pool.
+                items:
+                  description: RaidGroup contains the details of a raid group for
+                    the pool
+                  properties:
+                    blockDevices:
+                      items:
+                        description: CStorPoolInstanceBlockDevice contains the details
+                          of block devices that constitutes a raid group.
+                        properties:
+                          blockDeviceName:
+                            description: BlockDeviceName is the name of the block
+                              device.
+                            type: string
+                          capacity:
+                            description: Capacity is the capacity of the block device.
+                              It is system generated
+                            format: int64
+                            type: integer
+                          devLink:
+                            description: DevLink is the dev link for block devices
+                            type: string
+                        required:
+                        - blockDeviceName
+                        type: object
+                      type: array
+                  required:
+                  - blockDevices
+                  type: object
+                type: array
+              hostName:
+                description: HostName is the name of kubernetes node where the pool
+                  should be created.
+                type: string
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector is the labels that will be used to select
+                  a node for pool provisioning. Required field
+                type: object
+              poolConfig:
+                description: PoolConfig is the default pool config that applies to
+                  the pool on node.
+                properties:
+                  auxResources:
+                    description: AuxResources are the compute resources required by
+                      the cstor-pool pod side car containers.
+                    nullable: true
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  compression:
+                    description: 'Compression to enable compression Optional -- defaults
+                      to off Possible values : lz, off'
+                    type: string
+                  dataRaidGroupType:
+                    description: DataRaidGroupType is the  raid type.
+                    type: string
+                  priorityClassName:
+                    description: PriorityClassName if specified applies to this pool
+                      pod If left empty, DefaultPriorityClassName is applied. (See
+                      CStorPoolClusterSpec.DefaultPriorityClassName) If both are empty,
+                      not priority class is applied.
+                    nullable: true
+                    type: string
+                  resources:
+                    description: Resources are the compute resources required by the
+                      cstor-pool container.
+                    nullable: true
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  roThresholdLimit:
+                    description: 'ROThresholdLimit is threshold(percentage base) limit
+                      for pool read only mode. If ROThresholdLimit(%) amount of pool
+                      storage is reached then pool will set to readonly. NOTE: 1.
+                      If ROThresholdLimit is set to 100 then entire    pool storage
+                      will be used by default it will be set to 85%. 2. ROThresholdLimit
+                      value will be 0 <= ROThresholdLimit <= 100.'
+                    nullable: true
+                    type: integer
+                  thickProvision:
+                    description: ThickProvision to enable thick provisioning Optional
+                      -- defaults to false
+                    type: boolean
+                  tolerations:
+                    description: Tolerations, if specified, the pool pod's tolerations.
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using
+                        the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match.
+                            Empty means match all taint effects. When specified, allowed
+                            values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to
+                            the value. Valid operators are Exists and Equal. Defaults
+                            to Equal. Exists is equivalent to wildcard for value,
+                            so that a pod can tolerate all taints of a particular
+                            category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of
+                            time the toleration (which must be of effect NoExecute,
+                            otherwise this field is ignored) tolerates the taint.
+                            By default, it is not set, which means tolerate the taint
+                            forever (do not evict). Zero and negative values will
+                            be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    nullable: true
+                    type: array
+                  writeCacheGroupType:
+                    description: WriteCacheGroupType is the write cache raid type.
+                    type: string
+                required:
+                - dataRaidGroupType
+                type: object
+              writeCacheRaidGroups:
+                description: WriteCacheRaidGroups is the write cache raid group.
+                items:
+                  description: RaidGroup contains the details of a raid group for
+                    the pool
+                  properties:
+                    blockDevices:
+                      items:
+                        description: CStorPoolInstanceBlockDevice contains the details
+                          of block devices that constitutes a raid group.
+                        properties:
+                          blockDeviceName:
+                            description: BlockDeviceName is the name of the block
+                              device.
+                            type: string
+                          capacity:
+                            description: Capacity is the capacity of the block device.
+                              It is system generated
+                            format: int64
+                            type: integer
+                          devLink:
+                            description: DevLink is the dev link for block devices
+                            type: string
+                        required:
+                        - blockDeviceName
+                        type: object
+                      type: array
+                  required:
+                  - blockDevices
+                  type: object
+                nullable: true
+                type: array
+            required:
+            - dataRaidGroups
+            - nodeSelector
+            type: object
+          status:
+            description: Status is the possible statuses of the cstorpoolinstance
+              resource.
+            properties:
+              capacity:
+                description: Capacity describes the capacity details of a cstor pool
+                properties:
+                  free:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: Amount of usable space in the pool after excluding
+                      metadata and raid parity
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  total:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: Sum of usable capacity in all the data raidgroups
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  used:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: Amount of physical data (and its metadata) written
+                      to pool after applying compression, etc..,
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  zfs:
+                    description: ZFSCapacityAttributes contains advanced information
+                      about pool capacity details
+                    properties:
+                      logicalUsed:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: LogicalUsed is the amount of space that is "logically"
+                          consumed by this pool and all its descendents. The logical
+                          space ignores the effect of the compression and copies properties,
+                          giving a quantity closer to the amount of data that applications
+                          see. However, it does include space consumed by metadata.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                    required:
+                    - logicalUsed
+                    type: object
+                required:
+                - free
+                - total
+                - used
+                - zfs
+                type: object
+              conditions:
+                description: Current state of CSPI with details.
+                items:
+                  description: CSPIConditionType describes the state of a CSPI at
+                    a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    lastUpdateTime:
+                      description: The last time this condition was updated.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of CSPC condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              healthyReplicas:
+                description: HealthyReplicas describes the total count of healthy
+                  Volume Replicas in the cstor pool
+                format: int32
+                type: integer
+              phase:
+                description: ' The phase of a CStorPool is a simple, high-level summary
+                  of the pool state on the  node.'
+                type: string
+              provisionedReplicas:
+                description: ProvisionedReplicas describes the total count of Volume
+                  Replicas present in the cstor pool
+                format: int32
+                type: integer
+              readOnly:
+                description: ReadOnly if pool is readOnly or not
+                type: boolean
+            required:
+            - healthyReplicas
+            - provisionedReplicas
+            - readOnly
+            type: object
+          versionDetails:
+            description: VersionDetails is the openebs version.
+            properties:
+              autoUpgrade:
+                description: If AutoUpgrade is set to true then the resource is upgraded
+                  automatically without any manual steps
+                type: boolean
+              desired:
+                description: Desired is the version that we want to upgrade or the
+                  control plane version
+                type: string
+              status:
+                description: Status gives the status of reconciliation triggered when
+                  the desired and current version are not same
+                properties:
+                  current:
+                    description: Current is the version of resource
+                    type: string
+                  dependentsUpgraded:
+                    description: DependentsUpgraded gives the details whether all
+                      children of a resource are upgraded to desired version or not
+                    type: boolean
+                  lastUpdateTime:
+                    description: LastUpdateTime is the time the status was last  updated
+                    format: date-time
+                    nullable: true
+                    type: string
+                  message:
+                    description: Message is a human readable message if some error
+                      occurs
+                    type: string
+                  reason:
+                    description: Reason is the actual reason for the error state
+                    type: string
+                  state:
+                    description: State is the state of reconciliation
+                    type: string
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  name: cstorrestores.cstor.openebs.io
+spec:
+  group: cstor.openebs.io
+  names:
+    kind: CStorRestore
+    listKind: CStorRestoreList
+    plural: cstorrestores
+    shortNames:
+    - crestore
+    singular: cstorrestore
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Name of the snapshot which is restored
+      jsonPath: .spec.restoreName
+      name: Backup
+      type: string
+    - description: Volume on which restore is performed
+      jsonPath: .spec.volumeName
+      name: Volume
+      type: string
+    - description: Identifies the state of the restore
+      jsonPath: .status
+      name: Status
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: CStorRestore describes a cstor restore resource created as a
+          custom resource
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CStorRestoreSpec is the spec for a CStorRestore resource
+            properties:
+              localRestore:
+                description: Local defines whether restore is from local/remote
+                type: boolean
+              maxretrycount:
+                description: MaxRestoreRetryCount is the maximum number of attempt,
+                  will be performed to restore
+                type: integer
+              restoreName:
+                description: RestoreName holds restore name
+                type: string
+              restoreSrc:
+                description: RestoreSrc can be ip:port in case of restore from remote
+                  or volumeName in case of local restore
+                type: string
+              retrycount:
+                description: RetryCount represents the number of restore attempts
+                  performed for the restore
+                type: integer
+              size:
+                anyOf:
+                - type: integer
+                - type: string
+                description: Size represents the size of a snapshot to restore
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+              storageClass:
+                description: StorageClass represents name of StorageClass of restore
+                  volume
+                type: string
+              volumeName:
+                description: VolumeName is used to restore the data to corresponding
+                  volume
+                type: string
+            required:
+            - restoreName
+            - restoreSrc
+            - volumeName
+            type: object
+          status:
+            description: CStorRestoreStatus is a string type that represents the status
+              of the restore
+            type: string
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  name: cstorvolumeconfigs.cstor.openebs.io
+spec:
+  group: cstor.openebs.io
+  names:
+    kind: CStorVolumeConfig
+    listKind: CStorVolumeConfigList
+    plural: cstorvolumeconfigs
+    shortNames:
+    - cvc
+    singular: cstorvolumeconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Identifies the volume capacity
+      jsonPath: .status.capacity.storage
+      name: Capacity
+      type: string
+    - description: Identifies the volume provisioning status
+      jsonPath: .status.phase
+      name: Status
+      type: string
+    - description: Age of CStorVolumeReplica
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: CStorVolumeConfig describes a cstor volume config resource created
+          as custom resource. CStorVolumeConfig is a request for creating cstor volume
+          related resources like deployment, svc etc.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          publish:
+            description: Publish contains info related to attachment of a volume to
+              a node. i.e. NodeId etc.
+            properties:
+              nodeId:
+                description: NodeID contains publish info related to attachment of
+                  a volume to a node.
+                type: string
+            type: object
+          spec:
+            description: Spec defines a specification of a cstor volume config required
+              to provisione cstor volume resources
+            properties:
+              capacity:
+                additionalProperties:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                description: Capacity represents the actual resources of the underlying
+                  cstor volume.
+                type: object
+              cstorVolumeRef:
+                description: CStorVolumeRef has the information about where CstorVolumeClaim
+                  is created from.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              cstorVolumeSource:
+                description: CStorVolumeSource contains the source volumeName@snapShotname
+                  combaination.  This will be filled only if it is a clone creation.
+                type: string
+              policy:
+                description: Policy contains volume specific required policies target
+                  and replicas
+                properties:
+                  provision:
+                    description: replicaAffinity is set to true then volume replica
+                      resources need to be distributed across the pool instances
+                    properties:
+                      blockSize:
+                        description: BlockSize is the logical block size in multiple
+                          of 512 bytes BlockSize specifies the block size of the volume.
+                          The blocksize cannot be changed once the volume has been
+                          written, so it should be set at volume creation time. The
+                          default blocksize for volumes is 4 Kbytes. Any power of
+                          2 from 512 bytes to 128 Kbytes is valid.
+                        format: int32
+                        type: integer
+                      replicaAffinity:
+                        description: replicaAffinity is set to true then volume replica
+                          resources need to be distributed across the cstor pool instances
+                          based on the given topology
+                        type: boolean
+                    required:
+                    - replicaAffinity
+                    type: object
+                  replica:
+                    description: ReplicaSpec represents configuration related to replicas
+                      resources
+                    properties:
+                      compression:
+                        description: The zle compression algorithm compresses runs
+                          of zeros.
+                        type: string
+                      zvolWorkers:
+                        description: IOWorkers represents number of threads that executes
+                          client IOs
+                        type: string
+                    type: object
+                  replicaPoolInfo:
+                    description: 'ReplicaPoolInfo holds the pool information of volume
+                      replicas. Ex: If volume is provisioned on which CStor pool volume
+                      replicas exist'
+                    items:
+                      description: ReplicaPoolInfo represents the pool information
+                        of volume replica
+                      properties:
+                        poolName:
+                          description: PoolName represents the pool name where volume
+                            replica exists
+                          type: string
+                      required:
+                      - poolName
                       type: object
                     type: array
-                  nodeSelector:
-                    additionalProperties:
-                      type: string
-                    description: NodeSelector is the labels that will be used to select
-                      a node for pool provisioning. Required field
-                    type: object
-                  poolConfig:
-                    description: PoolConfig is the default pool config that applies
-                      to the pool on node.
+                  target:
+                    description: TargetSpec represents configuration related to cstor
+                      target and its resources
                     properties:
+                      affinity:
+                        description: PodAffinity if specified, are the target pod's
+                          affinities
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the affinity expressions specified
+                              by this field, but it may choose a node that violates
+                              one or more of the expressions. The node that is most
+                              preferred is the one with the greatest sum of weights,
+                              i.e. for each node that meets all of the scheduling
+                              requirements (resource request, requiredDuringScheduling
+                              affinity expressions, etc.), compute a sum by iterating
+                              through the elements of this field and adding "weight"
+                              to the sum if the node has pods which matches the corresponding
+                              podAffinityTerm; the node(s) with the highest sum are
+                              the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the
+                                    corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by
+                              this field are not met at scheduling time, the pod will
+                              not be scheduled onto the node. If the affinity requirements
+                              specified by this field cease to be met at some point
+                              during pod execution (e.g. due to a pod label update),
+                              the system may or may not try to eventually evict the
+                              pod from its node. When there are multiple elements,
+                              the lists of nodes corresponding to each podAffinityTerm
+                              are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s))
+                                that this pod should be co-located (affinity) or not
+                                co-located (anti-affinity) with, where co-located
+                                is defined as running on a node whose value of the
+                                label with key <topologyKey> matches that of any node
+                                on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces
+                                    the labelSelector applies to (matches against);
+                                    null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
                       auxResources:
                         description: AuxResources are the compute resources required
-                          by the cstor-pool pod side car containers.
-                        nullable: true
+                          by the cstor-target pod side car containers.
                         properties:
                           limits:
                             additionalProperties:
@@ -342,24 +1634,37 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                             type: object
                         type: object
-                      compression:
-                        description: 'Compression to enable compression Optional --
-                          defaults to off Possible values : lz, off'
-                        type: string
-                      dataRaidGroupType:
-                        description: DataRaidGroupType is the  raid type.
-                        type: string
+                      luWorkers:
+                        description: IOWorkers sets the number of threads that are
+                          working on above queue
+                        format: int64
+                        type: integer
+                      monitor:
+                        description: Monitor enables or disables the target exporter
+                          sidecar
+                        type: boolean
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: NodeSelector is the labels that will be used
+                          to select a node for target pod scheduleing Required field
+                        type: object
                       priorityClassName:
                         description: PriorityClassName if specified applies to this
-                          pool pod If left empty, DefaultPriorityClassName is applied.
-                          (See CStorPoolClusterSpec.DefaultPriorityClassName) If both
-                          are empty, not priority class is applied.
-                        nullable: true
+                          target pod If left empty, no priority class is applied.
                         type: string
+                      queueDepth:
+                        description: QueueDepth sets the queue size at iSCSI target
+                          which limits the ongoing IO count from client
+                        type: string
+                      replicationFactor:
+                        description: ReplicationFactor represents maximum number of
+                          replicas that are allowed to connect to the target
+                        format: int64
+                        type: integer
                       resources:
                         description: Resources are the compute resources required
-                          by the cstor-pool container.
-                        nullable: true
+                          by the cstor-target container.
                         properties:
                           limits:
                             additionalProperties:
@@ -385,22 +1690,9 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                             type: object
                         type: object
-                      roThresholdLimit:
-                        description: 'ROThresholdLimit is threshold(percentage base)
-                          limit for pool read only mode. If ROThresholdLimit(%) amount
-                          of pool storage is reached then pool will set to readonly.
-                          NOTE: 1. If ROThresholdLimit is set to 100 then entire    pool
-                          storage will be used by default it will be set to 85%. 2.
-                          ROThresholdLimit value will be 0 <= ROThresholdLimit <=
-                          100.'
-                        nullable: true
-                        type: integer
-                      thickProvision:
-                        description: ThickProvision to enable thick provisioning Optional
-                          -- defaults to false
-                        type: boolean
                       tolerations:
-                        description: Tolerations, if specified, the pool pod's tolerations.
+                        description: Tolerations, if specified, are the target pod's
+                          tolerations
                         items:
                           description: The pod this Toleration is attached to tolerates
                             any taint that matches the triple <key,value,effect> using
@@ -440,1430 +1732,142 @@ spec:
                                 be empty, otherwise just a regular string.
                               type: string
                           type: object
-                        nullable: true
                         type: array
-                      writeCacheGroupType:
-                        description: WriteCacheGroupType is the write cache raid type.
-                        type: string
-                    required:
-                    - dataRaidGroupType
                     type: object
-                  writeCacheRaidGroups:
-                    description: WriteCacheRaidGroups is the write cache raid group.
-                    items:
-                      description: RaidGroup contains the details of a raid group
-                        for the pool
-                      properties:
-                        blockDevices:
-                          items:
-                            description: CStorPoolInstanceBlockDevice contains the
-                              details of block devices that constitutes a raid group.
-                            properties:
-                              blockDeviceName:
-                                description: BlockDeviceName is the name of the block
-                                  device.
-                                type: string
-                              capacity:
-                                description: Capacity is the capacity of the block
-                                  device. It is system generated
-                                format: int64
-                                type: integer
-                              devLink:
-                                description: DevLink is the dev link for block devices
-                                type: string
-                            required:
-                            - blockDeviceName
-                            type: object
-                          type: array
-                      required:
-                      - blockDevices
-                      type: object
-                    nullable: true
-                    type: array
-                required:
-                - dataRaidGroups
-                - nodeSelector
                 type: object
-              type: array
-            priorityClassName:
-              description: DefaultPriorityClassName if specified applies to all the
-                pool pods in the pool spec if the priorityClass at the pool level
-                is not specified.
-              type: string
-            resources:
-              description: DefaultResources are the compute resources required by
-                the cstor-pool container. If the resources at PoolConfig is not specified,
-                this is written to CSPI PoolConfig.
-              nullable: true
-              properties:
-                limits:
-                  additionalProperties:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  description: 'Limits describes the maximum amount of compute resources
-                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                  type: object
-                requests:
-                  additionalProperties:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  description: 'Requests describes the minimum amount of compute resources
-                    required. If Requests is omitted for a container, it defaults
-                    to Limits if that is explicitly specified, otherwise to an implementation-defined
-                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                  type: object
-              type: object
-            tolerations:
-              description: Tolerations, if specified, are the pool pod's tolerations
-                If tolerations at PoolConfig is empty, this is written to CSPI PoolConfig.
-              items:
-                description: The pod this Toleration is attached to tolerates any
-                  taint that matches the triple <key,value,effect> using the matching
-                  operator <operator>.
+              provision:
+                description: Provision represents the initial volume configuration
+                  for the underlying cstor volume based on the persistent volume request
+                  by user. Provision properties are immutable
                 properties:
-                  effect:
-                    description: Effect indicates the taint effect to match. Empty
-                      means match all taint effects. When specified, allowed values
-                      are NoSchedule, PreferNoSchedule and NoExecute.
-                    type: string
-                  key:
-                    description: Key is the taint key that the toleration applies
-                      to. Empty means match all taint keys. If the key is empty, operator
-                      must be Exists; this combination means to match all values and
-                      all keys.
-                    type: string
-                  operator:
-                    description: Operator represents a key's relationship to the value.
-                      Valid operators are Exists and Equal. Defaults to Equal. Exists
-                      is equivalent to wildcard for value, so that a pod can tolerate
-                      all taints of a particular category.
-                    type: string
-                  tolerationSeconds:
-                    description: TolerationSeconds represents the period of time the
-                      toleration (which must be of effect NoExecute, otherwise this
-                      field is ignored) tolerates the taint. By default, it is not
-                      set, which means tolerate the taint forever (do not evict).
-                      Zero and negative values will be treated as 0 (evict immediately)
-                      by the system.
-                    format: int64
-                    type: integer
-                  value:
-                    description: Value is the taint value the toleration matches to.
-                      If the operator is Exists, the value should be empty, otherwise
-                      just a regular string.
-                    type: string
-                type: object
-              nullable: true
-              type: array
-          type: object
-        status:
-          description: CStorPoolClusterStatus represents the latest available observations
-            of a CSPC's current state.
-          properties:
-            conditions:
-              description: Current state of CSPC.
-              items:
-                description: CStorPoolClusterCondition describes the state of a CSPC
-                  at a certain point.
-                properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
-                    format: date-time
-                    type: string
-                  lastUpdateTime:
-                    description: The last time this condition was updated.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A human readable message indicating details about
-                      the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type of CSPC condition.
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              nullable: true
-              type: array
-            desiredInstances:
-              description: DesiredInstances is the number of CSPI(s) that should be
-                provisioned.
-              format: int32
-              nullable: true
-              type: integer
-            healthyInstances:
-              description: HealthyInstances is the number of CSPI(s) that are healthy.
-              format: int32
-              nullable: true
-              type: integer
-            provisionedInstances:
-              description: ProvisionedInstances is the the number of CSPI present
-                at the current state.
-              format: int32
-              nullable: true
-              type: integer
-          type: object
-        versionDetails:
-          description: VersionDetails provides the details for upgrade
-          properties:
-            autoUpgrade:
-              description: If AutoUpgrade is set to true then the resource is upgraded
-                automatically without any manual steps
-              type: boolean
-            desired:
-              description: Desired is the version that we want to upgrade or the control
-                plane version
-              type: string
-            status:
-              description: Status gives the status of reconciliation triggered when
-                the desired and current version are not same
-              properties:
-                current:
-                  description: Current is the version of resource
-                  type: string
-                dependentsUpgraded:
-                  description: DependentsUpgraded gives the details whether all children
-                    of a resource are upgraded to desired version or not
-                  type: boolean
-                lastUpdateTime:
-                  description: LastUpdateTime is the time the status was last  updated
-                  format: date-time
-                  nullable: true
-                  type: string
-                message:
-                  description: Message is a human readable message if some error occurs
-                  type: string
-                reason:
-                  description: Reason is the actual reason for the error state
-                  type: string
-                state:
-                  description: State is the state of reconciliation
-                  type: string
-              type: object
-          type: object
-      required:
-      - spec
-      type: object
-  version: v1
-  versions:
-  - name: v1
-    served: true
-    storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.2.9
-  creationTimestamp: null
-  name: cstorpoolinstances.cstor.openebs.io
-spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.hostName
-    description: Host name where cstorpool instances scheduled
-    name: HostName
-    type: string
-  - JSONPath: .status.capacity.used
-    description: The amount of storage space within the pool that has been physically
-      allocated
-    name: Allocated
-    priority: 1
-    type: string
-  - JSONPath: .status.capacity.free
-    description: The amount of usable free space available in the pool
-    name: Free
-    type: string
-  - JSONPath: .status.capacity.total
-    description: Total amount of usable space in pool
-    name: Capacity
-    type: string
-  - JSONPath: .status.readOnly
-    description: Identifies the pool read only mode
-    name: ReadOnly
-    type: boolean
-  - JSONPath: .status.provisionedReplicas
-    description: Represents no.of replicas present in the pool
-    name: ProvisionedReplicas
-    type: integer
-  - JSONPath: .status.healthyReplicas
-    description: Represents no.of healthy replicas present in the pool
-    name: HealthyReplicas
-    type: integer
-  - JSONPath: .spec.poolConfig.dataRaidGroupType
-    description: Represents the type of the storage pool
-    name: Type
-    priority: 1
-    type: string
-  - JSONPath: .status.phase
-    description: Identifies the current health of the pool
-    name: Status
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: Age of CStorPoolInstance
-    name: Age
-    type: date
-  group: cstor.openebs.io
-  names:
-    kind: CStorPoolInstance
-    listKind: CStorPoolInstanceList
-    plural: cstorpoolinstances
-    shortNames:
-    - cspi
-    singular: cstorpoolinstance
-  preserveUnknownFields: false
-  scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: CStorPoolInstance describes a cstor pool instance resource.
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: Spec is the specification of the cstorpoolinstance resource.
-          properties:
-            dataRaidGroups:
-              description: DataRaidGroups is the raid group configuration for the
-                given pool.
-              items:
-                description: RaidGroup contains the details of a raid group for the
-                  pool
-                properties:
-                  blockDevices:
-                    items:
-                      description: CStorPoolInstanceBlockDevice contains the details
-                        of block devices that constitutes a raid group.
-                      properties:
-                        blockDeviceName:
-                          description: BlockDeviceName is the name of the block device.
-                          type: string
-                        capacity:
-                          description: Capacity is the capacity of the block device.
-                            It is system generated
-                          format: int64
-                          type: integer
-                        devLink:
-                          description: DevLink is the dev link for block devices
-                          type: string
-                      required:
-                      - blockDeviceName
-                      type: object
-                    type: array
-                required:
-                - blockDevices
-                type: object
-              type: array
-            hostName:
-              description: HostName is the name of kubernetes node where the pool
-                should be created.
-              type: string
-            nodeSelector:
-              additionalProperties:
-                type: string
-              description: NodeSelector is the labels that will be used to select
-                a node for pool provisioning. Required field
-              type: object
-            poolConfig:
-              description: PoolConfig is the default pool config that applies to the
-                pool on node.
-              properties:
-                auxResources:
-                  description: AuxResources are the compute resources required by
-                    the cstor-pool pod side car containers.
-                  nullable: true
-                  properties:
-                    limits:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute
-                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                    requests:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Requests describes the minimum amount of compute
-                        resources required. If Requests is omitted for a container,
-                        it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                  type: object
-                compression:
-                  description: 'Compression to enable compression Optional -- defaults
-                    to off Possible values : lz, off'
-                  type: string
-                dataRaidGroupType:
-                  description: DataRaidGroupType is the  raid type.
-                  type: string
-                priorityClassName:
-                  description: PriorityClassName if specified applies to this pool
-                    pod If left empty, DefaultPriorityClassName is applied. (See CStorPoolClusterSpec.DefaultPriorityClassName)
-                    If both are empty, not priority class is applied.
-                  nullable: true
-                  type: string
-                resources:
-                  description: Resources are the compute resources required by the
-                    cstor-pool container.
-                  nullable: true
-                  properties:
-                    limits:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute
-                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                    requests:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Requests describes the minimum amount of compute
-                        resources required. If Requests is omitted for a container,
-                        it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                  type: object
-                roThresholdLimit:
-                  description: 'ROThresholdLimit is threshold(percentage base) limit
-                    for pool read only mode. If ROThresholdLimit(%) amount of pool
-                    storage is reached then pool will set to readonly. NOTE: 1. If
-                    ROThresholdLimit is set to 100 then entire    pool storage will
-                    be used by default it will be set to 85%. 2. ROThresholdLimit
-                    value will be 0 <= ROThresholdLimit <= 100.'
-                  nullable: true
-                  type: integer
-                thickProvision:
-                  description: ThickProvision to enable thick provisioning Optional
-                    -- defaults to false
-                  type: boolean
-                tolerations:
-                  description: Tolerations, if specified, the pool pod's tolerations.
-                  items:
-                    description: The pod this Toleration is attached to tolerates
-                      any taint that matches the triple <key,value,effect> using the
-                      matching operator <operator>.
-                    properties:
-                      effect:
-                        description: Effect indicates the taint effect to match. Empty
-                          means match all taint effects. When specified, allowed values
-                          are NoSchedule, PreferNoSchedule and NoExecute.
-                        type: string
-                      key:
-                        description: Key is the taint key that the toleration applies
-                          to. Empty means match all taint keys. If the key is empty,
-                          operator must be Exists; this combination means to match
-                          all values and all keys.
-                        type: string
-                      operator:
-                        description: Operator represents a key's relationship to the
-                          value. Valid operators are Exists and Equal. Defaults to
-                          Equal. Exists is equivalent to wildcard for value, so that
-                          a pod can tolerate all taints of a particular category.
-                        type: string
-                      tolerationSeconds:
-                        description: TolerationSeconds represents the period of time
-                          the toleration (which must be of effect NoExecute, otherwise
-                          this field is ignored) tolerates the taint. By default,
-                          it is not set, which means tolerate the taint forever (do
-                          not evict). Zero and negative values will be treated as
-                          0 (evict immediately) by the system.
-                        format: int64
-                        type: integer
-                      value:
-                        description: Value is the taint value the toleration matches
-                          to. If the operator is Exists, the value should be empty,
-                          otherwise just a regular string.
-                        type: string
-                    type: object
-                  nullable: true
-                  type: array
-                writeCacheGroupType:
-                  description: WriteCacheGroupType is the write cache raid type.
-                  type: string
-              required:
-              - dataRaidGroupType
-              type: object
-            writeCacheRaidGroups:
-              description: WriteCacheRaidGroups is the write cache raid group.
-              items:
-                description: RaidGroup contains the details of a raid group for the
-                  pool
-                properties:
-                  blockDevices:
-                    items:
-                      description: CStorPoolInstanceBlockDevice contains the details
-                        of block devices that constitutes a raid group.
-                      properties:
-                        blockDeviceName:
-                          description: BlockDeviceName is the name of the block device.
-                          type: string
-                        capacity:
-                          description: Capacity is the capacity of the block device.
-                            It is system generated
-                          format: int64
-                          type: integer
-                        devLink:
-                          description: DevLink is the dev link for block devices
-                          type: string
-                      required:
-                      - blockDeviceName
-                      type: object
-                    type: array
-                required:
-                - blockDevices
-                type: object
-              nullable: true
-              type: array
-          required:
-          - dataRaidGroups
-          - nodeSelector
-          type: object
-        status:
-          description: Status is the possible statuses of the cstorpoolinstance resource.
-          properties:
-            capacity:
-              description: Capacity describes the capacity details of a cstor pool
-              properties:
-                free:
-                  anyOf:
-                  - type: integer
-                  - type: string
-                  description: Amount of usable space in the pool after excluding
-                    metadata and raid parity
-                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                  x-kubernetes-int-or-string: true
-                total:
-                  anyOf:
-                  - type: integer
-                  - type: string
-                  description: Sum of usable capacity in all the data raidgroups
-                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                  x-kubernetes-int-or-string: true
-                used:
-                  anyOf:
-                  - type: integer
-                  - type: string
-                  description: Amount of physical data (and its metadata) written
-                    to pool after applying compression, etc..,
-                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                  x-kubernetes-int-or-string: true
-                zfs:
-                  description: ZFSCapacityAttributes contains advanced information
-                    about pool capacity details
-                  properties:
-                    logicalUsed:
+                  capacity:
+                    additionalProperties:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: LogicalUsed is the amount of space that is "logically"
-                        consumed by this pool and all its descendents. The logical
-                        space ignores the effect of the compression and copies properties,
-                        giving a quantity closer to the amount of data that applications
-                        see. However, it does include space consumed by metadata.
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                  required:
-                  - logicalUsed
-                  type: object
-              required:
-              - free
-              - total
-              - used
-              - zfs
-              type: object
-            conditions:
-              description: Current state of CSPI with details.
-              items:
-                description: CSPIConditionType describes the state of a CSPI at a
-                  certain point.
-                properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
-                    format: date-time
-                    type: string
-                  lastUpdateTime:
-                    description: The last time this condition was updated.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A human readable message indicating details about
-                      the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type of CSPC condition.
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            healthyReplicas:
-              description: HealthyReplicas describes the total count of healthy Volume
-                Replicas in the cstor pool
-              format: int32
-              type: integer
-            phase:
-              description: ' The phase of a CStorPool is a simple, high-level summary
-                of the pool state on the  node.'
-              type: string
-            provisionedReplicas:
-              description: ProvisionedReplicas describes the total count of Volume
-                Replicas present in the cstor pool
-              format: int32
-              type: integer
-            readOnly:
-              description: ReadOnly if pool is readOnly or not
-              type: boolean
-          required:
-          - healthyReplicas
-          - provisionedReplicas
-          - readOnly
-          type: object
-        versionDetails:
-          description: VersionDetails is the openebs version.
-          properties:
-            autoUpgrade:
-              description: If AutoUpgrade is set to true then the resource is upgraded
-                automatically without any manual steps
-              type: boolean
-            desired:
-              description: Desired is the version that we want to upgrade or the control
-                plane version
-              type: string
-            status:
-              description: Status gives the status of reconciliation triggered when
-                the desired and current version are not same
-              properties:
-                current:
-                  description: Current is the version of resource
-                  type: string
-                dependentsUpgraded:
-                  description: DependentsUpgraded gives the details whether all children
-                    of a resource are upgraded to desired version or not
-                  type: boolean
-                lastUpdateTime:
-                  description: LastUpdateTime is the time the status was last  updated
-                  format: date-time
-                  nullable: true
-                  type: string
-                message:
-                  description: Message is a human readable message if some error occurs
-                  type: string
-                reason:
-                  description: Reason is the actual reason for the error state
-                  type: string
-                state:
-                  description: State is the state of reconciliation
-                  type: string
-              type: object
-          type: object
-      required:
-      - spec
-      type: object
-  version: v1
-  versions:
-  - name: v1
-    served: true
-    storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.2.9
-  creationTimestamp: null
-  name: cstorrestores.cstor.openebs.io
-spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.restoreName
-    description: Name of the snapshot which is restored
-    name: Backup
-    type: string
-  - JSONPath: .spec.volumeName
-    description: Volume on which restore is performed
-    name: Volume
-    type: string
-  - JSONPath: .status
-    description: Identifies the state of the restore
-    name: Status
-    type: string
-  group: cstor.openebs.io
-  names:
-    kind: CStorRestore
-    listKind: CStorRestoreList
-    plural: cstorrestores
-    shortNames:
-    - crestore
-    singular: cstorrestore
-  preserveUnknownFields: false
-  scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: CStorRestore describes a cstor restore resource created as a custom
-        resource
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: CStorRestoreSpec is the spec for a CStorRestore resource
-          properties:
-            localRestore:
-              description: Local defines whether restore is from local/remote
-              type: boolean
-            maxretrycount:
-              description: MaxRestoreRetryCount is the maximum number of attempt,
-                will be performed to restore
-              type: integer
-            restoreName:
-              description: RestoreName holds restore name
-              type: string
-            restoreSrc:
-              description: RestoreSrc can be ip:port in case of restore from remote
-                or volumeName in case of local restore
-              type: string
-            retrycount:
-              description: RetryCount represents the number of restore attempts performed
-                for the restore
-              type: integer
-            size:
-              anyOf:
-              - type: integer
-              - type: string
-              description: Size represents the size of a snapshot to restore
-              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-              x-kubernetes-int-or-string: true
-            storageClass:
-              description: StorageClass represents name of StorageClass of restore
-                volume
-              type: string
-            volumeName:
-              description: VolumeName is used to restore the data to corresponding
-                volume
-              type: string
-          required:
-          - restoreName
-          - restoreSrc
-          - volumeName
-          type: object
-        status:
-          description: CStorRestoreStatus is a string type that represents the status
-            of the restore
-          type: string
-      required:
-      - spec
-      type: object
-  version: v1
-  versions:
-  - name: v1
-    served: true
-    storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.2.9
-  creationTimestamp: null
-  name: cstorvolumeconfigs.cstor.openebs.io
-spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.capacity.storage
-    description: Identifies the volume capacity
-    name: Capacity
-    type: string
-  - JSONPath: .status.phase
-    description: Identifies the volume provisioning status
-    name: Status
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: Age of CStorVolumeReplica
-    name: Age
-    type: date
-  group: cstor.openebs.io
-  names:
-    kind: CStorVolumeConfig
-    listKind: CStorVolumeConfigList
-    plural: cstorvolumeconfigs
-    shortNames:
-    - cvc
-    singular: cstorvolumeconfig
-  preserveUnknownFields: false
-  scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: CStorVolumeConfig describes a cstor volume config resource created
-        as custom resource. CStorVolumeConfig is a request for creating cstor volume
-        related resources like deployment, svc etc.
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        publish:
-          description: Publish contains info related to attachment of a volume to
-            a node. i.e. NodeId etc.
-          properties:
-            nodeId:
-              description: NodeID contains publish info related to attachment of a
-                volume to a node.
-              type: string
-          type: object
-        spec:
-          description: Spec defines a specification of a cstor volume config required
-            to provisione cstor volume resources
-          properties:
-            capacity:
-              additionalProperties:
-                anyOf:
-                - type: integer
-                - type: string
-                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                x-kubernetes-int-or-string: true
-              description: Capacity represents the actual resources of the underlying
-                cstor volume.
-              type: object
-            cstorVolumeRef:
-              description: CStorVolumeRef has the information about where CstorVolumeClaim
-                is created from.
-              properties:
-                apiVersion:
-                  description: API version of the referent.
-                  type: string
-                fieldPath:
-                  description: 'If referring to a piece of an object instead of an
-                    entire object, this string should contain a valid JSON/Go field
-                    access statement, such as desiredState.manifest.containers[2].
-                    For example, if the object reference is to a container within
-                    a pod, this would take on a value like: "spec.containers{name}"
-                    (where "name" refers to the name of the container that triggered
-                    the event) or if no container name is specified "spec.containers[2]"
-                    (container with index 2 in this pod). This syntax is chosen only
-                    to have some well-defined way of referencing a part of an object.
-                    TODO: this design is not final and this field is subject to change
-                    in the future.'
-                  type: string
-                kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                  type: string
-                namespace:
-                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                  type: string
-                resourceVersion:
-                  description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                  type: string
-                uid:
-                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                  type: string
-              type: object
-            cstorVolumeSource:
-              description: CStorVolumeSource contains the source volumeName@snapShotname
-                combaination.  This will be filled only if it is a clone creation.
-              type: string
-            policy:
-              description: Policy contains volume specific required policies target
-                and replicas
-              properties:
-                provision:
-                  description: replicaAffinity is set to true then volume replica
-                    resources need to be distributed across the pool instances
-                  properties:
-                    blockSize:
-                      description: BlockSize is the logical block size in multiple
-                        of 512 bytes BlockSize specifies the block size of the volume.
-                        The blocksize cannot be changed once the volume has been written,
-                        so it should be set at volume creation time. The default blocksize
-                        for volumes is 4 Kbytes. Any power of 2 from 512 bytes to
-                        128 Kbytes is valid.
-                      format: int32
-                      type: integer
-                    replicaAffinity:
-                      description: replicaAffinity is set to true then volume replica
-                        resources need to be distributed across the cstor pool instances
-                        based on the given topology
-                      type: boolean
-                  required:
-                  - replicaAffinity
-                  type: object
-                replica:
-                  description: ReplicaSpec represents configuration related to replicas
-                    resources
-                  properties:
-                    compression:
-                      description: The zle compression algorithm compresses runs of
-                        zeros.
-                      type: string
-                    zvolWorkers:
-                      description: IOWorkers represents number of threads that executes
-                        client IOs
-                      type: string
-                  type: object
-                replicaPoolInfo:
-                  description: 'ReplicaPoolInfo holds the pool information of volume
-                    replicas. Ex: If volume is provisioned on which CStor pool volume
-                    replicas exist'
-                  items:
-                    description: ReplicaPoolInfo represents the pool information of
-                      volume replica
-                    properties:
-                      poolName:
-                        description: PoolName represents the pool name where volume
-                          replica exists
-                        type: string
-                    required:
-                    - poolName
+                    description: Capacity represents initial capacity of volume replica
+                      required during volume clone operations to maintain some metadata
+                      info related to child resources like snapshot, cloned volumes.
                     type: object
-                  type: array
-                target:
-                  description: TargetSpec represents configuration related to cstor
-                    target and its resources
+                  replicaCount:
+                    description: ReplicaCount represents initial cstor volume replica
+                      count, its will not be updated later on based on scale up/down
+                      operations, only readonly operations and validations.
+                    type: integer
+                required:
+                - capacity
+                - replicaCount
+                type: object
+            required:
+            - capacity
+            - policy
+            - provision
+            type: object
+          status:
+            description: Status represents the current information/status for the
+              cstor volume config, populated by the controller.
+            properties:
+              capacity:
+                additionalProperties:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                description: Capacity the actual resources of the underlying volume.
+                type: object
+              condition:
+                items:
+                  description: CStorVolumeConfigCondition contains details about state
+                    of cstor volume
                   properties:
-                    affinity:
-                      description: PodAffinity if specified, are the target pod's
-                        affinities
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods
-                            to nodes that satisfy the affinity expressions specified
-                            by this field, but it may choose a node that violates
-                            one or more of the expressions. The node that is most
-                            preferred is the one with the greatest sum of weights,
-                            i.e. for each node that meets all of the scheduling requirements
-                            (resource request, requiredDuringScheduling affinity expressions,
-                            etc.), compute a sum by iterating through the elements
-                            of this field and adding "weight" to the sum if the node
-                            has pods which matches the corresponding podAffinityTerm;
-                            the node(s) with the highest sum are the most preferred.
-                          items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm
-                              fields are added per-node to find the most preferred
-                              node(s)
-                            properties:
-                              podAffinityTerm:
-                                description: Required. A pod affinity term, associated
-                                  with the corresponding weight.
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies which namespaces
-                                      the labelSelector applies to (matches against);
-                                      null or empty list means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified
-                                      namespaces, where co-located is defined as running
-                                      on a node whose value of the label with key
-                                      topologyKey matches that of any node on which
-                                      any of the selected pods is running. Empty topologyKey
-                                      is not allowed.
-                                    type: string
-                                required:
-                                - topologyKey
-                                type: object
-                              weight:
-                                description: weight associated with matching the corresponding
-                                  podAffinityTerm, in the range 1-100.
-                                format: int32
-                                type: integer
-                            required:
-                            - podAffinityTerm
-                            - weight
-                            type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this
-                            field are not met at scheduling time, the pod will not
-                            be scheduled onto the node. If the affinity requirements
-                            specified by this field cease to be met at some point
-                            during pod execution (e.g. due to a pod label update),
-                            the system may or may not try to eventually evict the
-                            pod from its node. When there are multiple elements, the
-                            lists of nodes corresponding to each podAffinityTerm are
-                            intersected, i.e. all terms must be satisfied.
-                          items:
-                            description: Defines a set of pods (namely those matching
-                              the labelSelector relative to the given namespace(s))
-                              that this pod should be co-located (affinity) or not
-                              co-located (anti-affinity) with, where co-located is
-                              defined as running on a node whose value of the label
-                              with key <topologyKey> matches that of any node on which
-                              a pod of the set of pods is running
-                            properties:
-                              labelSelector:
-                                description: A label query over a set of resources,
-                                  in this case pods.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                type: object
-                              namespaces:
-                                description: namespaces specifies which namespaces
-                                  the labelSelector applies to (matches against);
-                                  null or empty list means "this pod's namespace"
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                description: This pod should be co-located (affinity)
-                                  or not co-located (anti-affinity) with the pods
-                                  matching the labelSelector in the specified namespaces,
-                                  where co-located is defined as running on a node
-                                  whose value of the label with key topologyKey matches
-                                  that of any node on which any of the selected pods
-                                  is running. Empty topologyKey is not allowed.
-                                type: string
-                            required:
-                            - topologyKey
-                            type: object
-                          type: array
-                      type: object
-                    auxResources:
-                      description: AuxResources are the compute resources required
-                        by the cstor-target pod side car containers.
-                      properties:
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute
-                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute
-                            resources required. If Requests is omitted for a container,
-                            it defaults to Limits if that is explicitly specified,
-                            otherwise to an implementation-defined value. More info:
-                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                      type: object
-                    luWorkers:
-                      description: IOWorkers sets the number of threads that are working
-                        on above queue
-                      format: int64
-                      type: integer
-                    monitor:
-                      description: Monitor enables or disables the target exporter
-                        sidecar
-                      type: boolean
-                    nodeSelector:
-                      additionalProperties:
-                        type: string
-                      description: NodeSelector is the labels that will be used to
-                        select a node for target pod scheduleing Required field
-                      type: object
-                    priorityClassName:
-                      description: PriorityClassName if specified applies to this
-                        target pod If left empty, no priority class is applied.
+                    lastProbeTime:
+                      description: Last time we probed the condition.
+                      format: date-time
                       type: string
-                    queueDepth:
-                      description: QueueDepth sets the queue size at iSCSI target
-                        which limits the ongoing IO count from client
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
                       type: string
-                    replicationFactor:
-                      description: ReplicationFactor represents maximum number of
-                        replicas that are allowed to connect to the target
-                      format: int64
-                      type: integer
-                    resources:
-                      description: Resources are the compute resources required by
-                        the cstor-target container.
-                      properties:
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute
-                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute
-                            resources required. If Requests is omitted for a container,
-                            it defaults to Limits if that is explicitly specified,
-                            otherwise to an implementation-defined value. More info:
-                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                      type: object
-                    tolerations:
-                      description: Tolerations, if specified, are the target pod's
-                        tolerations
-                      items:
-                        description: The pod this Toleration is attached to tolerates
-                          any taint that matches the triple <key,value,effect> using
-                          the matching operator <operator>.
-                        properties:
-                          effect:
-                            description: Effect indicates the taint effect to match.
-                              Empty means match all taint effects. When specified,
-                              allowed values are NoSchedule, PreferNoSchedule and
-                              NoExecute.
-                            type: string
-                          key:
-                            description: Key is the taint key that the toleration
-                              applies to. Empty means match all taint keys. If the
-                              key is empty, operator must be Exists; this combination
-                              means to match all values and all keys.
-                            type: string
-                          operator:
-                            description: Operator represents a key's relationship
-                              to the value. Valid operators are Exists and Equal.
-                              Defaults to Equal. Exists is equivalent to wildcard
-                              for value, so that a pod can tolerate all taints of
-                              a particular category.
-                            type: string
-                          tolerationSeconds:
-                            description: TolerationSeconds represents the period of
-                              time the toleration (which must be of effect NoExecute,
-                              otherwise this field is ignored) tolerates the taint.
-                              By default, it is not set, which means tolerate the
-                              taint forever (do not evict). Zero and negative values
-                              will be treated as 0 (evict immediately) by the system.
-                            format: int64
-                            type: integer
-                          value:
-                            description: Value is the taint value the toleration matches
-                              to. If the operator is Exists, the value should be empty,
-                              otherwise just a regular string.
-                            type: string
-                        type: object
-                      type: array
+                    message:
+                      description: Human-readable message indicating details about
+                        last transition.
+                      type: string
+                    reason:
+                      description: Reason is a brief CamelCase string that describes
+                        any failure
+                      type: string
+                    type:
+                      description: Current Condition of cstor volume config. If underlying
+                        persistent volume is being resized then the Condition will
+                        be set to 'ResizeStarted' etc
+                      type: string
+                  required:
+                  - message
+                  - reason
+                  - type
                   type: object
-              type: object
-            provision:
-              description: Provision represents the initial volume configuration for
-                the underlying cstor volume based on the persistent volume request
-                by user. Provision properties are immutable
-              properties:
-                capacity:
-                  additionalProperties:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  description: Capacity represents initial capacity of volume replica
-                    required during volume clone operations to maintain some metadata
-                    info related to child resources like snapshot, cloned volumes.
-                  type: object
-                replicaCount:
-                  description: ReplicaCount represents initial cstor volume replica
-                    count, its will not be updated later on based on scale up/down
-                    operations, only readonly operations and validations.
-                  type: integer
-              required:
-              - capacity
-              - replicaCount
-              type: object
-          required:
-          - capacity
-          - policy
-          - provision
-          type: object
-        status:
-          description: Status represents the current information/status for the cstor
-            volume config, populated by the controller.
-          properties:
-            capacity:
-              additionalProperties:
-                anyOf:
-                - type: integer
-                - type: string
-                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                x-kubernetes-int-or-string: true
-              description: Capacity the actual resources of the underlying volume.
-              type: object
-            condition:
-              items:
-                description: CStorVolumeConfigCondition contains details about state
-                  of cstor volume
+                type: array
+              phase:
+                description: Phase represents the current phase of CStorVolumeConfig.
+                type: string
+              poolInfo:
+                description: PoolInfo represents current pool names where volume replicas
+                  exists
+                items:
+                  type: string
+                type: array
+            type: object
+          versionDetails:
+            description: VersionDetails provides the details for upgrade
+            properties:
+              autoUpgrade:
+                description: If AutoUpgrade is set to true then the resource is upgraded
+                  automatically without any manual steps
+                type: boolean
+              desired:
+                description: Desired is the version that we want to upgrade or the
+                  control plane version
+                type: string
+              status:
+                description: Status gives the status of reconciliation triggered when
+                  the desired and current version are not same
                 properties:
-                  lastProbeTime:
-                    description: Last time we probed the condition.
-                    format: date-time
+                  current:
+                    description: Current is the version of resource
                     type: string
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
+                  dependentsUpgraded:
+                    description: DependentsUpgraded gives the details whether all
+                      children of a resource are upgraded to desired version or not
+                    type: boolean
+                  lastUpdateTime:
+                    description: LastUpdateTime is the time the status was last  updated
                     format: date-time
+                    nullable: true
                     type: string
                   message:
-                    description: Human-readable message indicating details about last
-                      transition.
+                    description: Message is a human readable message if some error
+                      occurs
                     type: string
                   reason:
-                    description: Reason is a brief CamelCase string that describes
-                      any failure
+                    description: Reason is the actual reason for the error state
                     type: string
-                  type:
-                    description: Current Condition of cstor volume config. If underlying
-                      persistent volume is being resized then the Condition will be
-                      set to 'ResizeStarted' etc
+                  state:
+                    description: State is the state of reconciliation
                     type: string
-                required:
-                - message
-                - reason
-                - type
                 type: object
-              type: array
-            phase:
-              description: Phase represents the current phase of CStorVolumeConfig.
-              type: string
-            poolInfo:
-              description: PoolInfo represents current pool names where volume replicas
-                exists
-              items:
-                type: string
-              type: array
-          type: object
-        versionDetails:
-          description: VersionDetails provides the details for upgrade
-          properties:
-            autoUpgrade:
-              description: If AutoUpgrade is set to true then the resource is upgraded
-                automatically without any manual steps
-              type: boolean
-            desired:
-              description: Desired is the version that we want to upgrade or the control
-                plane version
-              type: string
-            status:
-              description: Status gives the status of reconciliation triggered when
-                the desired and current version are not same
-              properties:
-                current:
-                  description: Current is the version of resource
-                  type: string
-                dependentsUpgraded:
-                  description: DependentsUpgraded gives the details whether all children
-                    of a resource are upgraded to desired version or not
-                  type: boolean
-                lastUpdateTime:
-                  description: LastUpdateTime is the time the status was last  updated
-                  format: date-time
-                  nullable: true
-                  type: string
-                message:
-                  description: Message is a human readable message if some error occurs
-                  type: string
-                reason:
-                  description: Reason is the actual reason for the error state
-                  type: string
-                state:
-                  description: State is the state of reconciliation
-                  type: string
-              type: object
-          type: object
-      required:
-      - spec
-      - status
-      - versionDetails
-      type: object
-  version: v1
-  versions:
-  - name: v1
+            type: object
+        required:
+        - spec
+        - status
+        - versionDetails
+        type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""
@@ -1872,11 +1876,11 @@ status:
   storedVersions: []
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.9
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: cstorvolumepolicies.cstor.openebs.io
 spec:
@@ -1888,401 +1892,407 @@ spec:
     shortNames:
     - cvp
     singular: cstorvolumepolicy
-  preserveUnknownFields: false
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      description: CStorVolumePolicy describes a configuration required for cstor
-        volume resources
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: Spec defines a configuration info of a cstor volume required
-            to provisione cstor volume resources
-          properties:
-            provision:
-              description: replicaAffinity is set to true then volume replica resources
-                need to be distributed across the pool instances
-              properties:
-                blockSize:
-                  description: BlockSize is the logical block size in multiple of
-                    512 bytes BlockSize specifies the block size of the volume. The
-                    blocksize cannot be changed once the volume has been written,
-                    so it should be set at volume creation time. The default blocksize
-                    for volumes is 4 Kbytes. Any power of 2 from 512 bytes to 128
-                    Kbytes is valid.
-                  format: int32
-                  type: integer
-                replicaAffinity:
-                  description: replicaAffinity is set to true then volume replica
-                    resources need to be distributed across the cstor pool instances
-                    based on the given topology
-                  type: boolean
-              required:
-              - replicaAffinity
-              type: object
-            replica:
-              description: ReplicaSpec represents configuration related to replicas
-                resources
-              properties:
-                compression:
-                  description: The zle compression algorithm compresses runs of zeros.
-                  type: string
-                zvolWorkers:
-                  description: IOWorkers represents number of threads that executes
-                    client IOs
-                  type: string
-              type: object
-            replicaPoolInfo:
-              description: 'ReplicaPoolInfo holds the pool information of volume replicas.
-                Ex: If volume is provisioned on which CStor pool volume replicas exist'
-              items:
-                description: ReplicaPoolInfo represents the pool information of volume
-                  replica
-                properties:
-                  poolName:
-                    description: PoolName represents the pool name where volume replica
-                      exists
-                    type: string
-                required:
-                - poolName
-                type: object
-              type: array
-            target:
-              description: TargetSpec represents configuration related to cstor target
-                and its resources
-              properties:
-                affinity:
-                  description: PodAffinity if specified, are the target pod's affinities
-                  properties:
-                    preferredDuringSchedulingIgnoredDuringExecution:
-                      description: The scheduler will prefer to schedule pods to nodes
-                        that satisfy the affinity expressions specified by this field,
-                        but it may choose a node that violates one or more of the
-                        expressions. The node that is most preferred is the one with
-                        the greatest sum of weights, i.e. for each node that meets
-                        all of the scheduling requirements (resource request, requiredDuringScheduling
-                        affinity expressions, etc.), compute a sum by iterating through
-                        the elements of this field and adding "weight" to the sum
-                        if the node has pods which matches the corresponding podAffinityTerm;
-                        the node(s) with the highest sum are the most preferred.
-                      items:
-                        description: The weights of all of the matched WeightedPodAffinityTerm
-                          fields are added per-node to find the most preferred node(s)
-                        properties:
-                          podAffinityTerm:
-                            description: Required. A pod affinity term, associated
-                              with the corresponding weight.
-                            properties:
-                              labelSelector:
-                                description: A label query over a set of resources,
-                                  in this case pods.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                type: object
-                              namespaces:
-                                description: namespaces specifies which namespaces
-                                  the labelSelector applies to (matches against);
-                                  null or empty list means "this pod's namespace"
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                description: This pod should be co-located (affinity)
-                                  or not co-located (anti-affinity) with the pods
-                                  matching the labelSelector in the specified namespaces,
-                                  where co-located is defined as running on a node
-                                  whose value of the label with key topologyKey matches
-                                  that of any node on which any of the selected pods
-                                  is running. Empty topologyKey is not allowed.
-                                type: string
-                            required:
-                            - topologyKey
-                            type: object
-                          weight:
-                            description: weight associated with matching the corresponding
-                              podAffinityTerm, in the range 1-100.
-                            format: int32
-                            type: integer
-                        required:
-                        - podAffinityTerm
-                        - weight
-                        type: object
-                      type: array
-                    requiredDuringSchedulingIgnoredDuringExecution:
-                      description: If the affinity requirements specified by this
-                        field are not met at scheduling time, the pod will not be
-                        scheduled onto the node. If the affinity requirements specified
-                        by this field cease to be met at some point during pod execution
-                        (e.g. due to a pod label update), the system may or may not
-                        try to eventually evict the pod from its node. When there
-                        are multiple elements, the lists of nodes corresponding to
-                        each podAffinityTerm are intersected, i.e. all terms must
-                        be satisfied.
-                      items:
-                        description: Defines a set of pods (namely those matching
-                          the labelSelector relative to the given namespace(s)) that
-                          this pod should be co-located (affinity) or not co-located
-                          (anti-affinity) with, where co-located is defined as running
-                          on a node whose value of the label with key <topologyKey>
-                          matches that of any node on which a pod of the set of pods
-                          is running
-                        properties:
-                          labelSelector:
-                            description: A label query over a set of resources, in
-                              this case pods.
-                            properties:
-                              matchExpressions:
-                                description: matchExpressions is a list of label selector
-                                  requirements. The requirements are ANDed.
-                                items:
-                                  description: A label selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: key is the label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: operator represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists and DoesNotExist.
-                                      type: string
-                                    values:
-                                      description: values is an array of string values.
-                                        If the operator is In or NotIn, the values
-                                        array must be non-empty. If the operator is
-                                        Exists or DoesNotExist, the values array must
-                                        be empty. This array is replaced during a
-                                        strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchLabels:
-                                additionalProperties:
-                                  type: string
-                                description: matchLabels is a map of {key,value} pairs.
-                                  A single {key,value} in the matchLabels map is equivalent
-                                  to an element of matchExpressions, whose key field
-                                  is "key", the operator is "In", and the values array
-                                  contains only "value". The requirements are ANDed.
-                                type: object
-                            type: object
-                          namespaces:
-                            description: namespaces specifies which namespaces the
-                              labelSelector applies to (matches against); null or
-                              empty list means "this pod's namespace"
-                            items:
-                              type: string
-                            type: array
-                          topologyKey:
-                            description: This pod should be co-located (affinity)
-                              or not co-located (anti-affinity) with the pods matching
-                              the labelSelector in the specified namespaces, where
-                              co-located is defined as running on a node whose value
-                              of the label with key topologyKey matches that of any
-                              node on which any of the selected pods is running. Empty
-                              topologyKey is not allowed.
-                            type: string
-                        required:
-                        - topologyKey
-                        type: object
-                      type: array
-                  type: object
-                auxResources:
-                  description: AuxResources are the compute resources required by
-                    the cstor-target pod side car containers.
-                  properties:
-                    limits:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute
-                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                    requests:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Requests describes the minimum amount of compute
-                        resources required. If Requests is omitted for a container,
-                        it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                  type: object
-                luWorkers:
-                  description: IOWorkers sets the number of threads that are working
-                    on above queue
-                  format: int64
-                  type: integer
-                monitor:
-                  description: Monitor enables or disables the target exporter sidecar
-                  type: boolean
-                nodeSelector:
-                  additionalProperties:
-                    type: string
-                  description: NodeSelector is the labels that will be used to select
-                    a node for target pod scheduleing Required field
-                  type: object
-                priorityClassName:
-                  description: PriorityClassName if specified applies to this target
-                    pod If left empty, no priority class is applied.
-                  type: string
-                queueDepth:
-                  description: QueueDepth sets the queue size at iSCSI target which
-                    limits the ongoing IO count from client
-                  type: string
-                replicationFactor:
-                  description: ReplicationFactor represents maximum number of replicas
-                    that are allowed to connect to the target
-                  format: int64
-                  type: integer
-                resources:
-                  description: Resources are the compute resources required by the
-                    cstor-target container.
-                  properties:
-                    limits:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute
-                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                    requests:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Requests describes the minimum amount of compute
-                        resources required. If Requests is omitted for a container,
-                        it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                  type: object
-                tolerations:
-                  description: Tolerations, if specified, are the target pod's tolerations
-                  items:
-                    description: The pod this Toleration is attached to tolerates
-                      any taint that matches the triple <key,value,effect> using the
-                      matching operator <operator>.
-                    properties:
-                      effect:
-                        description: Effect indicates the taint effect to match. Empty
-                          means match all taint effects. When specified, allowed values
-                          are NoSchedule, PreferNoSchedule and NoExecute.
-                        type: string
-                      key:
-                        description: Key is the taint key that the toleration applies
-                          to. Empty means match all taint keys. If the key is empty,
-                          operator must be Exists; this combination means to match
-                          all values and all keys.
-                        type: string
-                      operator:
-                        description: Operator represents a key's relationship to the
-                          value. Valid operators are Exists and Equal. Defaults to
-                          Equal. Exists is equivalent to wildcard for value, so that
-                          a pod can tolerate all taints of a particular category.
-                        type: string
-                      tolerationSeconds:
-                        description: TolerationSeconds represents the period of time
-                          the toleration (which must be of effect NoExecute, otherwise
-                          this field is ignored) tolerates the taint. By default,
-                          it is not set, which means tolerate the taint forever (do
-                          not evict). Zero and negative values will be treated as
-                          0 (evict immediately) by the system.
-                        format: int64
-                        type: integer
-                      value:
-                        description: Value is the taint value the toleration matches
-                          to. If the operator is Exists, the value should be empty,
-                          otherwise just a regular string.
-                        type: string
-                    type: object
-                  type: array
-              type: object
-          type: object
-        status:
-          description: CStorVolumePolicyStatus is for handling status of CstorVolumePolicy
-          properties:
-            phase:
-              type: string
-          type: object
-      required:
-      - spec
-      type: object
-  version: v1
   versions:
   - name: v1
+    schema:
+      openAPIV3Schema:
+        description: CStorVolumePolicy describes a configuration required for cstor
+          volume resources
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines a configuration info of a cstor volume required
+              to provisione cstor volume resources
+            properties:
+              provision:
+                description: replicaAffinity is set to true then volume replica resources
+                  need to be distributed across the pool instances
+                properties:
+                  blockSize:
+                    description: BlockSize is the logical block size in multiple of
+                      512 bytes BlockSize specifies the block size of the volume.
+                      The blocksize cannot be changed once the volume has been written,
+                      so it should be set at volume creation time. The default blocksize
+                      for volumes is 4 Kbytes. Any power of 2 from 512 bytes to 128
+                      Kbytes is valid.
+                    format: int32
+                    type: integer
+                  replicaAffinity:
+                    description: replicaAffinity is set to true then volume replica
+                      resources need to be distributed across the cstor pool instances
+                      based on the given topology
+                    type: boolean
+                required:
+                - replicaAffinity
+                type: object
+              replica:
+                description: ReplicaSpec represents configuration related to replicas
+                  resources
+                properties:
+                  compression:
+                    description: The zle compression algorithm compresses runs of
+                      zeros.
+                    type: string
+                  zvolWorkers:
+                    description: IOWorkers represents number of threads that executes
+                      client IOs
+                    type: string
+                type: object
+              replicaPoolInfo:
+                description: 'ReplicaPoolInfo holds the pool information of volume
+                  replicas. Ex: If volume is provisioned on which CStor pool volume
+                  replicas exist'
+                items:
+                  description: ReplicaPoolInfo represents the pool information of
+                    volume replica
+                  properties:
+                    poolName:
+                      description: PoolName represents the pool name where volume
+                        replica exists
+                      type: string
+                  required:
+                  - poolName
+                  type: object
+                type: array
+              target:
+                description: TargetSpec represents configuration related to cstor
+                  target and its resources
+                properties:
+                  affinity:
+                    description: PodAffinity if specified, are the target pod's affinities
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces
+                                    the labelSelector applies to (matches against);
+                                    null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to a pod label update), the system may or may
+                          not try to eventually evict the pod from its node. When
+                          there are multiple elements, the lists of nodes corresponding
+                          to each podAffinityTerm are intersected, i.e. all terms
+                          must be satisfied.
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies which namespaces the
+                                labelSelector applies to (matches against); null or
+                                empty list means "this pod's namespace"
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                  auxResources:
+                    description: AuxResources are the compute resources required by
+                      the cstor-target pod side car containers.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  luWorkers:
+                    description: IOWorkers sets the number of threads that are working
+                      on above queue
+                    format: int64
+                    type: integer
+                  monitor:
+                    description: Monitor enables or disables the target exporter sidecar
+                    type: boolean
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: NodeSelector is the labels that will be used to select
+                      a node for target pod scheduleing Required field
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName if specified applies to this target
+                      pod If left empty, no priority class is applied.
+                    type: string
+                  queueDepth:
+                    description: QueueDepth sets the queue size at iSCSI target which
+                      limits the ongoing IO count from client
+                    type: string
+                  replicationFactor:
+                    description: ReplicationFactor represents maximum number of replicas
+                      that are allowed to connect to the target
+                    format: int64
+                    type: integer
+                  resources:
+                    description: Resources are the compute resources required by the
+                      cstor-target container.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  tolerations:
+                    description: Tolerations, if specified, are the target pod's tolerations
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using
+                        the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match.
+                            Empty means match all taint effects. When specified, allowed
+                            values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to
+                            the value. Valid operators are Exists and Equal. Defaults
+                            to Equal. Exists is equivalent to wildcard for value,
+                            so that a pod can tolerate all taints of a particular
+                            category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of
+                            time the toleration (which must be of effect NoExecute,
+                            otherwise this field is ignored) tolerates the taint.
+                            By default, it is not set, which means tolerate the taint
+                            forever (do not evict). Zero and negative values will
+                            be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            type: object
+          status:
+            description: CStorVolumePolicyStatus is for handling status of CstorVolumePolicy
+            properties:
+              phase:
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
     served: true
     storage: true
 status:
@@ -2293,31 +2303,14 @@ status:
   storedVersions: []
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.9
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: cstorvolumereplicas.cstor.openebs.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.capacity.total
-    description: The amount of disk space consumed by a dataset and all its descendents
-    name: Allocated
-    type: string
-  - JSONPath: .status.capacity.used
-    description: The amount of space that is logically consumed by this dataset
-    name: Used
-    type: string
-  - JSONPath: .status.phase
-    description: Identifies the current state of the replicas
-    name: Status
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: Age of CStorVolumeReplica
-    name: Age
-    type: date
   group: cstor.openebs.io
   names:
     kind: CStorVolumeReplica
@@ -2326,182 +2319,200 @@ spec:
     shortNames:
     - cvr
     singular: cstorvolumereplica
-  preserveUnknownFields: false
   scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: CStorVolumeReplica describes a cstor volume resource created as
-        custom resource
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: CStorVolumeReplicaSpec is the spec for a CStorVolumeReplica
-            resource
-          properties:
-            blockSize:
-              description: BlockSize is the logical block size in multiple of 512
-                bytes BlockSize specifies the block size of the volume. The blocksize
-                cannot be changed once the volume has been written, so it should be
-                set at volume creation time. The default blocksize for volumes is
-                4 Kbytes. Any power of 2 from 512 bytes to 128 Kbytes is valid.
-              format: int32
-              type: integer
-            capacity:
-              description: Represents the actual capacity of the underlying volume
-              type: string
-            compression:
-              description: 'Controls the compression algorithm used for this volumes
-                examples: on|off|gzip|gzip-N|lz4|lzjb|zle'
-              type: string
-            replicaid:
-              description: ReplicaID is unique number to identify the replica
-              type: string
-            targetIP:
-              description: TargetIP represents iscsi target IP through which replica
-                cummunicates IO workloads and other volume operations like snapshot
-                and resize requests
-              type: string
-            zvolWorkers:
-              description: ZvolWorkers represents number of threads that executes
-                client IOs
-              type: string
-          type: object
-        status:
-          description: CStorVolumeReplicaStatus is for handling status of cvr.
-          properties:
-            capacity:
-              description: CStorVolumeCapacityDetails represents capacity info of
-                replica
-              properties:
-                total:
-                  description: The amount of space consumed by this volume replica
-                    and all its descendents
-                  type: string
-                used:
-                  description: The amount of space that is "logically" accessible
-                    by this dataset. The logical space ignores the effect of the compression
-                    and copies properties, giving a quantity closer to the amount
-                    of data that applications see.  However, it does include space
-                    consumed by metadata
-                  type: string
-              required:
-              - total
-              - used
-              type: object
-            lastTransitionTime:
-              description: LastTransitionTime refers to the time when the phase changes
-              format: date-time
-              nullable: true
-              type: string
-            lastUpdateTime:
-              description: The last updated time
-              format: date-time
-              nullable: true
-              type: string
-            message:
-              description: A human readable message indicating details about the transition.
-              type: string
-            pendingSnapshots:
-              additionalProperties:
-                description: CStorSnapshotInfo represents the snapshot information
-                  related to particular snapshot
-                properties:
-                  logicalReferenced:
-                    description: LogicalReferenced describes the amount of space that
-                      is "logically" accessable by this snapshot. This logical space
-                      ignores the effect of the compression and copies properties,
-                      giving a quantity closer to the amount of data that application
-                      see. It also includes space consumed by metadata.
-                    format: int64
-                    type: integer
-                required:
-                - logicalReferenced
-                type: object
-              description: PendingSnapshots contains list of pending snapshots that
-                are not yet available on this replica
-              type: object
-            phase:
-              description: CStorVolumeReplicaPhase is to holds different phases of
-                replica
-              type: string
-            snapshots:
-              additionalProperties:
-                description: CStorSnapshotInfo represents the snapshot information
-                  related to particular snapshot
-                properties:
-                  logicalReferenced:
-                    description: LogicalReferenced describes the amount of space that
-                      is "logically" accessable by this snapshot. This logical space
-                      ignores the effect of the compression and copies properties,
-                      giving a quantity closer to the amount of data that application
-                      see. It also includes space consumed by metadata.
-                    format: int64
-                    type: integer
-                required:
-                - logicalReferenced
-                type: object
-              description: Snapshots contains list of snapshots, and their properties,
-                created on CVR
-              type: object
-          type: object
-        versionDetails:
-          description: VersionDetails provides the details for upgrade
-          properties:
-            autoUpgrade:
-              description: If AutoUpgrade is set to true then the resource is upgraded
-                automatically without any manual steps
-              type: boolean
-            desired:
-              description: Desired is the version that we want to upgrade or the control
-                plane version
-              type: string
-            status:
-              description: Status gives the status of reconciliation triggered when
-                the desired and current version are not same
-              properties:
-                current:
-                  description: Current is the version of resource
-                  type: string
-                dependentsUpgraded:
-                  description: DependentsUpgraded gives the details whether all children
-                    of a resource are upgraded to desired version or not
-                  type: boolean
-                lastUpdateTime:
-                  description: LastUpdateTime is the time the status was last  updated
-                  format: date-time
-                  nullable: true
-                  type: string
-                message:
-                  description: Message is a human readable message if some error occurs
-                  type: string
-                reason:
-                  description: Reason is the actual reason for the error state
-                  type: string
-                state:
-                  description: State is the state of reconciliation
-                  type: string
-              type: object
-          type: object
-      required:
-      - spec
-      type: object
-  version: v1
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: The amount of disk space consumed by a dataset and all its descendents
+      jsonPath: .status.capacity.total
+      name: Allocated
+      type: string
+    - description: The amount of space that is logically consumed by this dataset
+      jsonPath: .status.capacity.used
+      name: Used
+      type: string
+    - description: Identifies the current state of the replicas
+      jsonPath: .status.phase
+      name: Status
+      type: string
+    - description: Age of CStorVolumeReplica
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: CStorVolumeReplica describes a cstor volume resource created
+          as custom resource
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CStorVolumeReplicaSpec is the spec for a CStorVolumeReplica
+              resource
+            properties:
+              blockSize:
+                description: BlockSize is the logical block size in multiple of 512
+                  bytes BlockSize specifies the block size of the volume. The blocksize
+                  cannot be changed once the volume has been written, so it should
+                  be set at volume creation time. The default blocksize for volumes
+                  is 4 Kbytes. Any power of 2 from 512 bytes to 128 Kbytes is valid.
+                format: int32
+                type: integer
+              capacity:
+                description: Represents the actual capacity of the underlying volume
+                type: string
+              compression:
+                description: 'Controls the compression algorithm used for this volumes
+                  examples: on|off|gzip|gzip-N|lz4|lzjb|zle'
+                type: string
+              replicaid:
+                description: ReplicaID is unique number to identify the replica
+                type: string
+              targetIP:
+                description: TargetIP represents iscsi target IP through which replica
+                  cummunicates IO workloads and other volume operations like snapshot
+                  and resize requests
+                type: string
+              zvolWorkers:
+                description: ZvolWorkers represents number of threads that executes
+                  client IOs
+                type: string
+            type: object
+          status:
+            description: CStorVolumeReplicaStatus is for handling status of cvr.
+            properties:
+              capacity:
+                description: CStorVolumeCapacityDetails represents capacity info of
+                  replica
+                properties:
+                  total:
+                    description: The amount of space consumed by this volume replica
+                      and all its descendents
+                    type: string
+                  used:
+                    description: The amount of space that is "logically" accessible
+                      by this dataset. The logical space ignores the effect of the
+                      compression and copies properties, giving a quantity closer
+                      to the amount of data that applications see.  However, it does
+                      include space consumed by metadata
+                    type: string
+                required:
+                - total
+                - used
+                type: object
+              lastTransitionTime:
+                description: LastTransitionTime refers to the time when the phase
+                  changes
+                format: date-time
+                nullable: true
+                type: string
+              lastUpdateTime:
+                description: The last updated time
+                format: date-time
+                nullable: true
+                type: string
+              message:
+                description: A human readable message indicating details about the
+                  transition.
+                type: string
+              pendingSnapshots:
+                additionalProperties:
+                  description: CStorSnapshotInfo represents the snapshot information
+                    related to particular snapshot
+                  properties:
+                    logicalReferenced:
+                      description: LogicalReferenced describes the amount of space
+                        that is "logically" accessable by this snapshot. This logical
+                        space ignores the effect of the compression and copies properties,
+                        giving a quantity closer to the amount of data that application
+                        see. It also includes space consumed by metadata.
+                      format: int64
+                      type: integer
+                  required:
+                  - logicalReferenced
+                  type: object
+                description: PendingSnapshots contains list of pending snapshots that
+                  are not yet available on this replica
+                type: object
+              phase:
+                description: CStorVolumeReplicaPhase is to holds different phases
+                  of replica
+                type: string
+              snapshots:
+                additionalProperties:
+                  description: CStorSnapshotInfo represents the snapshot information
+                    related to particular snapshot
+                  properties:
+                    logicalReferenced:
+                      description: LogicalReferenced describes the amount of space
+                        that is "logically" accessable by this snapshot. This logical
+                        space ignores the effect of the compression and copies properties,
+                        giving a quantity closer to the amount of data that application
+                        see. It also includes space consumed by metadata.
+                      format: int64
+                      type: integer
+                  required:
+                  - logicalReferenced
+                  type: object
+                description: Snapshots contains list of snapshots, and their properties,
+                  created on CVR
+                type: object
+            type: object
+          versionDetails:
+            description: VersionDetails provides the details for upgrade
+            properties:
+              autoUpgrade:
+                description: If AutoUpgrade is set to true then the resource is upgraded
+                  automatically without any manual steps
+                type: boolean
+              desired:
+                description: Desired is the version that we want to upgrade or the
+                  control plane version
+                type: string
+              status:
+                description: Status gives the status of reconciliation triggered when
+                  the desired and current version are not same
+                properties:
+                  current:
+                    description: Current is the version of resource
+                    type: string
+                  dependentsUpgraded:
+                    description: DependentsUpgraded gives the details whether all
+                      children of a resource are upgraded to desired version or not
+                    type: boolean
+                  lastUpdateTime:
+                    description: LastUpdateTime is the time the status was last  updated
+                    format: date-time
+                    nullable: true
+                    type: string
+                  message:
+                    description: Message is a human readable message if some error
+                      occurs
+                    type: string
+                  reason:
+                    description: Reason is the actual reason for the error state
+                    type: string
+                  state:
+                    description: State is the state of reconciliation
+                    type: string
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""
@@ -2510,27 +2521,14 @@ status:
   storedVersions: []
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.9
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: cstorvolumes.cstor.openebs.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.capacity
-    description: Current volume capacity
-    name: Capacity
-    type: string
-  - JSONPath: .status.phase
-    description: Identifies the current health of the volume
-    name: Status
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: Age of CStorVolume
-    name: Age
-    type: date
   group: cstor.openebs.io
   names:
     kind: CStorVolume
@@ -2539,240 +2537,255 @@ spec:
     shortNames:
     - cv
     singular: cstorvolume
-  preserveUnknownFields: false
   scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: CStorVolume describes a cstor volume resource created as custom
-        resource
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: CStorVolumeSpec is the spec for a CStorVolume resource
-          properties:
-            capacity:
-              anyOf:
-              - type: integer
-              - type: string
-              description: Capacity represents the desired size of the underlying
-                volume.
-              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-              x-kubernetes-int-or-string: true
-            consistencyFactor:
-              description: ConsistencyFactor is minimum number of volume replicas
-                i.e. `RF/2 + 1` has to be connected to the target for write operations.
-                Basically more then 50% of replica has to be connected to target.
-              type: integer
-            desiredReplicationFactor:
-              description: DesiredReplicationFactor represents maximum number of replicas
-                that are allowed to connect to the target. Required for scale operations
-              type: integer
-            iqn:
-              description: Target iSCSI Qualified Name.combination of nodeBase
-              type: string
-            replicaDetails:
-              description: ReplicaDetails refers to the trusty replica information
-              properties:
-                knownReplicas:
-                  additionalProperties:
-                    type: string
-                  description: KnownReplicas represents the replicas that target can
-                    trust to read data
-                  type: object
-              type: object
-            replicationFactor:
-              description: ReplicationFactor represents number of volume replica created
-                during volume provisioning connect to the target
-              type: integer
-            targetIP:
-              description: TargetIP IP of the iSCSI target service
-              type: string
-            targetPort:
-              description: iSCSI Target Port typically TCP ports 3260
-              type: string
-            targetPortal:
-              description: iSCSI Target Portal. The Portal is combination of IP:port
-                (typically TCP ports 3260)
-              type: string
-          type: object
-        status:
-          description: CStorVolumeStatus is for handling status of cvr.
-          properties:
-            capacity:
-              anyOf:
-              - type: integer
-              - type: string
-              description: Represents the actual capacity of the underlying volume.
-              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-              x-kubernetes-int-or-string: true
-            conditions:
-              description: Current Condition of cstorvolume. If underlying persistent
-                volume is being resized then the Condition will be set to 'ResizePending'.
-              items:
-                description: CStorVolumeCondition contains details about state of
-                  cstorvolume
+  versions:
+  - additionalPrinterColumns:
+    - description: Current volume capacity
+      jsonPath: .status.capacity
+      name: Capacity
+      type: string
+    - description: Identifies the current health of the volume
+      jsonPath: .status.phase
+      name: Status
+      type: string
+    - description: Age of CStorVolume
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: CStorVolume describes a cstor volume resource created as custom
+          resource
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CStorVolumeSpec is the spec for a CStorVolume resource
+            properties:
+              capacity:
+                anyOf:
+                - type: integer
+                - type: string
+                description: Capacity represents the desired size of the underlying
+                  volume.
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+              consistencyFactor:
+                description: ConsistencyFactor is minimum number of volume replicas
+                  i.e. `RF/2 + 1` has to be connected to the target for write operations.
+                  Basically more then 50% of replica has to be connected to target.
+                type: integer
+              desiredReplicationFactor:
+                description: DesiredReplicationFactor represents maximum number of
+                  replicas that are allowed to connect to the target. Required for
+                  scale operations
+                type: integer
+              iqn:
+                description: Target iSCSI Qualified Name.combination of nodeBase
+                type: string
+              replicaDetails:
+                description: ReplicaDetails refers to the trusty replica information
                 properties:
-                  lastProbeTime:
-                    description: Last time we probed the condition.
-                    format: date-time
+                  knownReplicas:
+                    additionalProperties:
+                      type: string
+                    description: KnownReplicas represents the replicas that target
+                      can trust to read data
+                    type: object
+                type: object
+              replicationFactor:
+                description: ReplicationFactor represents number of volume replica
+                  created during volume provisioning connect to the target
+                type: integer
+              targetIP:
+                description: TargetIP IP of the iSCSI target service
+                type: string
+              targetPort:
+                description: iSCSI Target Port typically TCP ports 3260
+                type: string
+              targetPortal:
+                description: iSCSI Target Portal. The Portal is combination of IP:port
+                  (typically TCP ports 3260)
+                type: string
+            type: object
+          status:
+            description: CStorVolumeStatus is for handling status of cvr.
+            properties:
+              capacity:
+                anyOf:
+                - type: integer
+                - type: string
+                description: Represents the actual capacity of the underlying volume.
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+              conditions:
+                description: Current Condition of cstorvolume. If underlying persistent
+                  volume is being resized then the Condition will be set to 'ResizePending'.
+                items:
+                  description: CStorVolumeCondition contains details about state of
+                    cstorvolume
+                  properties:
+                    lastProbeTime:
+                      description: Last time we probed the condition.
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: Human-readable message indicating details about
+                        last transition.
+                      type: string
+                    reason:
+                      description: Unique, this should be a short, machine understandable
+                        string that gives the reason for condition's last transition.
+                        If it reports "ResizePending" that means the underlying cstorvolume
+                        is being resized.
+                      type: string
+                    status:
+                      description: ConditionStatus states in which state condition
+                        is present
+                      type: string
+                    type:
+                      description: CStorVolumeConditionType is a valid value of CStorVolumeCondition.Type
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastTransitionTime:
+                description: LastTransitionTime refers to the time when the phase
+                  changes
+                format: date-time
+                nullable: true
+                type: string
+              lastUpdateTime:
+                description: LastUpdateTime refers to the time when last status updated
+                  due to any operations
+                format: date-time
+                nullable: true
+                type: string
+              message:
+                description: A human-readable message indicating details about why
+                  the volume is in this state.
+                type: string
+              phase:
+                description: CStorVolumePhase is to hold result of action.
+                type: string
+              replicaDetails:
+                description: ReplicaDetails refers to the trusty replica information
+                properties:
+                  knownReplicas:
+                    additionalProperties:
+                      type: string
+                    description: KnownReplicas represents the replicas that target
+                      can trust to read data
+                    type: object
+                type: object
+              replicaStatuses:
+                items:
+                  description: ReplicaStatus stores the status of replicas
+                  properties:
+                    checkpointedIOSeq:
+                      description: Represents IO number of replica persisted on the
+                        disk
+                      type: string
+                    inflightRead:
+                      description: Ongoing reads I/O from target to replica
+                      type: string
+                    inflightSync:
+                      description: Ongoing sync I/O from target to replica
+                      type: string
+                    inflightWrite:
+                      description: ongoing writes I/O from target to replica
+                      type: string
+                    mode:
+                      description: Mode represents replica status i.e. Healthy, Degraded
+                      type: string
+                    quorum:
+                      description: 'Quorum indicates wheather data wrtitten to the
+                        replica is lost or exists. "0" means: data has been lost(
+                        might be ephimeral case) and will recostruct data from other
+                        Healthy replicas in a write-only mode 1 means: written data
+                        is exists on replica'
+                      type: string
+                    replicaId:
+                      description: ID is replica unique identifier
+                      type: string
+                    upTime:
+                      description: time since the replica connected to target
+                      type: integer
+                  required:
+                  - checkpointedIOSeq
+                  - inflightRead
+                  - inflightSync
+                  - inflightWrite
+                  - mode
+                  - quorum
+                  - replicaId
+                  - upTime
+                  type: object
+                type: array
+            type: object
+          versionDetails:
+            description: VersionDetails provides the details for upgrade
+            properties:
+              autoUpgrade:
+                description: If AutoUpgrade is set to true then the resource is upgraded
+                  automatically without any manual steps
+                type: boolean
+              desired:
+                description: Desired is the version that we want to upgrade or the
+                  control plane version
+                type: string
+              status:
+                description: Status gives the status of reconciliation triggered when
+                  the desired and current version are not same
+                properties:
+                  current:
+                    description: Current is the version of resource
                     type: string
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
+                  dependentsUpgraded:
+                    description: DependentsUpgraded gives the details whether all
+                      children of a resource are upgraded to desired version or not
+                    type: boolean
+                  lastUpdateTime:
+                    description: LastUpdateTime is the time the status was last  updated
                     format: date-time
+                    nullable: true
                     type: string
                   message:
-                    description: Human-readable message indicating details about last
-                      transition.
+                    description: Message is a human readable message if some error
+                      occurs
                     type: string
                   reason:
-                    description: Unique, this should be a short, machine understandable
-                      string that gives the reason for condition's last transition.
-                      If it reports "ResizePending" that means the underlying cstorvolume
-                      is being resized.
+                    description: Reason is the actual reason for the error state
                     type: string
-                  status:
-                    description: ConditionStatus states in which state condition is
-                      present
+                  state:
+                    description: State is the state of reconciliation
                     type: string
-                  type:
-                    description: CStorVolumeConditionType is a valid value of CStorVolumeCondition.Type
-                    type: string
-                required:
-                - status
-                - type
                 type: object
-              type: array
-            lastTransitionTime:
-              description: LastTransitionTime refers to the time when the phase changes
-              format: date-time
-              nullable: true
-              type: string
-            lastUpdateTime:
-              description: LastUpdateTime refers to the time when last status updated
-                due to any operations
-              format: date-time
-              nullable: true
-              type: string
-            message:
-              description: A human-readable message indicating details about why the
-                volume is in this state.
-              type: string
-            phase:
-              description: CStorVolumePhase is to hold result of action.
-              type: string
-            replicaDetails:
-              description: ReplicaDetails refers to the trusty replica information
-              properties:
-                knownReplicas:
-                  additionalProperties:
-                    type: string
-                  description: KnownReplicas represents the replicas that target can
-                    trust to read data
-                  type: object
-              type: object
-            replicaStatuses:
-              items:
-                description: ReplicaStatus stores the status of replicas
-                properties:
-                  checkpointedIOSeq:
-                    description: Represents IO number of replica persisted on the
-                      disk
-                    type: string
-                  inflightRead:
-                    description: Ongoing reads I/O from target to replica
-                    type: string
-                  inflightSync:
-                    description: Ongoing sync I/O from target to replica
-                    type: string
-                  inflightWrite:
-                    description: ongoing writes I/O from target to replica
-                    type: string
-                  mode:
-                    description: Mode represents replica status i.e. Healthy, Degraded
-                    type: string
-                  quorum:
-                    description: 'Quorum indicates wheather data wrtitten to the replica
-                      is lost or exists. "0" means: data has been lost( might be ephimeral
-                      case) and will recostruct data from other Healthy replicas in
-                      a write-only mode 1 means: written data is exists on replica'
-                    type: string
-                  replicaId:
-                    description: ID is replica unique identifier
-                    type: string
-                  upTime:
-                    description: time since the replica connected to target
-                    type: integer
-                required:
-                - checkpointedIOSeq
-                - inflightRead
-                - inflightSync
-                - inflightWrite
-                - mode
-                - quorum
-                - replicaId
-                - upTime
-                type: object
-              type: array
-          type: object
-        versionDetails:
-          description: VersionDetails provides the details for upgrade
-          properties:
-            autoUpgrade:
-              description: If AutoUpgrade is set to true then the resource is upgraded
-                automatically without any manual steps
-              type: boolean
-            desired:
-              description: Desired is the version that we want to upgrade or the control
-                plane version
-              type: string
-            status:
-              description: Status gives the status of reconciliation triggered when
-                the desired and current version are not same
-              properties:
-                current:
-                  description: Current is the version of resource
-                  type: string
-                dependentsUpgraded:
-                  description: DependentsUpgraded gives the details whether all children
-                    of a resource are upgraded to desired version or not
-                  type: boolean
-                lastUpdateTime:
-                  description: LastUpdateTime is the time the status was last  updated
-                  format: date-time
-                  nullable: true
-                  type: string
-                message:
-                  description: Message is a human readable message if some error occurs
-                  type: string
-                reason:
-                  description: Reason is the actual reason for the error state
-                  type: string
-                state:
-                  description: State is the state of reconciliation
-                  type: string
-              type: object
-          type: object
-      required:
-      - spec
-      type: object
-  version: v1
-  versions:
-  - name: v1
+            type: object
+        required:
+        - spec
+        type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/crds/all-crds.yaml
+++ b/config/crds/all-crds.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: cstorbackups.cstor.openebs.io
 spec:
@@ -99,7 +99,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: cstorcompletedbackups.cstor.openebs.io
 spec:
@@ -181,7 +181,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: cstorpoolclusters.cstor.openebs.io
 spec:
@@ -674,7 +674,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: cstorpoolinstances.cstor.openebs.io
 spec:
@@ -1131,7 +1131,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: cstorrestores.cstor.openebs.io
 spec:
@@ -1239,7 +1239,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: cstorvolumeconfigs.cstor.openebs.io
 spec:
@@ -1880,7 +1880,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: cstorvolumepolicies.cstor.openebs.io
 spec:
@@ -2307,7 +2307,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: cstorvolumereplicas.cstor.openebs.io
 spec:
@@ -2525,7 +2525,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: cstorvolumes.cstor.openebs.io
 spec:

--- a/config/crds/bases/cstor.openebs.io_cstorbackups.yaml
+++ b/config/crds/bases/cstor.openebs.io_cstorbackups.yaml
@@ -1,26 +1,13 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.9
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: cstorbackups.cstor.openebs.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.volumeName
-    description: Name of the volume for which this backup is destined
-    name: Volume
-    type: string
-  - JSONPath: .spec.backupName
-    description: Name of the backup or scheduled backup
-    name: Backup/Schedule
-    type: string
-  - JSONPath: .status
-    description: Identifies the phase of the backup
-    name: Status
-    type: string
   group: cstor.openebs.io
   names:
     kind: CStorBackup
@@ -29,65 +16,77 @@ spec:
     shortNames:
     - cbackup
     singular: cstorbackup
-  preserveUnknownFields: false
   scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: CStorBackup describes a cstor backup resource created as a custom
-        resource
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: CStorBackupSpec is the spec for a CStorBackup resource
-          properties:
-            backupDest:
-              description: BackupDest is the remote address for backup transfer
-              type: string
-            backupName:
-              description: BackupName is the name of the backup or scheduled backup
-              type: string
-            localSnap:
-              description: LocalSnap is the flag to enable local snapshot only
-              type: boolean
-            prevSnapName:
-              description: PrevSnapName is the last completed-backup's snapshot name
-              type: string
-            snapName:
-              description: SnapName is the name of the current backup snapshot
-              type: string
-            volumeName:
-              description: VolumeName is the name of the volume for which this backup
-                is destined
-              type: string
-          required:
-          - backupName
-          - snapName
-          - volumeName
-          type: object
-        status:
-          description: CStorBackupStatus is a string type that represents the status
-            of the backup
-          type: string
-      required:
-      - spec
-      type: object
-  version: v1
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: Name of the volume for which this backup is destined
+      jsonPath: .spec.volumeName
+      name: Volume
+      type: string
+    - description: Name of the backup or scheduled backup
+      jsonPath: .spec.backupName
+      name: Backup/Schedule
+      type: string
+    - description: Identifies the phase of the backup
+      jsonPath: .status
+      name: Status
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: CStorBackup describes a cstor backup resource created as a custom
+          resource
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CStorBackupSpec is the spec for a CStorBackup resource
+            properties:
+              backupDest:
+                description: BackupDest is the remote address for backup transfer
+                type: string
+              backupName:
+                description: BackupName is the name of the backup or scheduled backup
+                type: string
+              localSnap:
+                description: LocalSnap is the flag to enable local snapshot only
+                type: boolean
+              prevSnapName:
+                description: PrevSnapName is the last completed-backup's snapshot
+                  name
+                type: string
+              snapName:
+                description: SnapName is the name of the current backup snapshot
+                type: string
+              volumeName:
+                description: VolumeName is the name of the volume for which this backup
+                  is destined
+                type: string
+            required:
+            - backupName
+            - snapName
+            - volumeName
+            type: object
+          status:
+            description: CStorBackupStatus is a string type that represents the status
+              of the backup
+            type: string
+        required:
+        - spec
+        type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/crds/bases/cstor.openebs.io_cstorbackups.yaml
+++ b/config/crds/bases/cstor.openebs.io_cstorbackups.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: cstorbackups.cstor.openebs.io
 spec:

--- a/config/crds/bases/cstor.openebs.io_cstorcompletedbackups.yaml
+++ b/config/crds/bases/cstor.openebs.io_cstorcompletedbackups.yaml
@@ -1,26 +1,13 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.9
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: cstorcompletedbackups.cstor.openebs.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.volumeName
-    description: Volume name on which backup is performed
-    name: Volume
-    type: string
-  - JSONPath: .spec.backupName
-    description: Name of the backup or scheduled backup
-    name: Backup/Schedule
-    type: string
-  - JSONPath: .spec.lastSnapName
-    description: Last successfully backup snapshot
-    name: LastSnap
-    type: string
   group: cstor.openebs.io
   names:
     kind: CStorCompletedBackup
@@ -29,53 +16,64 @@ spec:
     shortNames:
     - ccompletedbackup
     singular: cstorcompletedbackup
-  preserveUnknownFields: false
   scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: CStorCompletedBackup describes a cstor completed-backup resource
-        created as custom resource
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: CStorCompletedBackupSpec is the spec for a CStorBackup resource
-          properties:
-            backupName:
-              description: BackupName is the name of backup or scheduled backup
-              type: string
-            lastSnapName:
-              description: LastSnapName is the name of last completed-backup's snapshot
-                name
-              type: string
-            secondLastSnapName:
-              description: SecondLastSnapName is the name of second last 'successfully'
-                completed-backup's snapshot
-              type: string
-            volumeName:
-              description: VolumeName is the name of volume for which this backup
-                is destined
-              type: string
-          type: object
-      required:
-      - spec
-      type: object
-  version: v1
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: Volume name on which backup is performed
+      jsonPath: .spec.volumeName
+      name: Volume
+      type: string
+    - description: Name of the backup or scheduled backup
+      jsonPath: .spec.backupName
+      name: Backup/Schedule
+      type: string
+    - description: Last successfully backup snapshot
+      jsonPath: .spec.lastSnapName
+      name: LastSnap
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: CStorCompletedBackup describes a cstor completed-backup resource
+          created as custom resource
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CStorCompletedBackupSpec is the spec for a CStorBackup resource
+            properties:
+              backupName:
+                description: BackupName is the name of backup or scheduled backup
+                type: string
+              lastSnapName:
+                description: LastSnapName is the name of last completed-backup's snapshot
+                  name
+                type: string
+              secondLastSnapName:
+                description: SecondLastSnapName is the name of second last 'successfully'
+                  completed-backup's snapshot
+                type: string
+              volumeName:
+                description: VolumeName is the name of volume for which this backup
+                  is destined
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/crds/bases/cstor.openebs.io_cstorcompletedbackups.yaml
+++ b/config/crds/bases/cstor.openebs.io_cstorcompletedbackups.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: cstorcompletedbackups.cstor.openebs.io
 spec:

--- a/config/crds/bases/cstor.openebs.io_cstorpoolclusters.yaml
+++ b/config/crds/bases/cstor.openebs.io_cstorpoolclusters.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: cstorpoolclusters.cstor.openebs.io
 spec:

--- a/config/crds/bases/cstor.openebs.io_cstorpoolclusters.yaml
+++ b/config/crds/bases/cstor.openebs.io_cstorpoolclusters.yaml
@@ -1,30 +1,13 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.9
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: cstorpoolclusters.cstor.openebs.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.healthyInstances
-    description: The number of healthy cStorPoolInstances
-    name: HealthyInstances
-    type: integer
-  - JSONPath: .status.provisionedInstances
-    description: The number of provisioned cStorPoolInstances
-    name: ProvisionedInstances
-    type: integer
-  - JSONPath: .status.desiredInstances
-    description: The number of desired cStorPoolInstances
-    name: DesiredInstances
-    type: integer
-  - JSONPath: .metadata.creationTimestamp
-    description: Age of CStorPoolCluster
-    name: Age
-    type: date
   group: cstor.openebs.io
   names:
     kind: CStorPoolCluster
@@ -33,457 +16,475 @@ spec:
     shortNames:
     - cspc
     singular: cstorpoolcluster
-  preserveUnknownFields: false
   scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: CStorPoolCluster describes a CStorPoolCluster custom resource.
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: CStorPoolClusterSpec is the spec for a CStorPoolClusterSpec
-            resource
-          properties:
-            auxResources:
-              description: AuxResources are the compute resources required by the
-                cstor-pool pod side car containers.
-              nullable: true
-              properties:
-                limits:
-                  additionalProperties:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  description: 'Limits describes the maximum amount of compute resources
-                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                  type: object
-                requests:
-                  additionalProperties:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  description: 'Requests describes the minimum amount of compute resources
-                    required. If Requests is omitted for a container, it defaults
-                    to Limits if that is explicitly specified, otherwise to an implementation-defined
-                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                  type: object
-              type: object
-            pools:
-              description: Pools is the spec for pools for various nodes where it
-                should be created.
-              items:
-                description: PoolSpec is the spec for pool on node where it should
-                  be created.
+  versions:
+  - additionalPrinterColumns:
+    - description: The number of healthy cStorPoolInstances
+      jsonPath: .status.healthyInstances
+      name: HealthyInstances
+      type: integer
+    - description: The number of provisioned cStorPoolInstances
+      jsonPath: .status.provisionedInstances
+      name: ProvisionedInstances
+      type: integer
+    - description: The number of desired cStorPoolInstances
+      jsonPath: .status.desiredInstances
+      name: DesiredInstances
+      type: integer
+    - description: Age of CStorPoolCluster
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: CStorPoolCluster describes a CStorPoolCluster custom resource.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CStorPoolClusterSpec is the spec for a CStorPoolClusterSpec
+              resource
+            properties:
+              auxResources:
+                description: AuxResources are the compute resources required by the
+                  cstor-pool pod side car containers.
+                nullable: true
                 properties:
-                  dataRaidGroups:
-                    description: DataRaidGroups is the raid group configuration for
-                      the given pool.
-                    items:
-                      description: RaidGroup contains the details of a raid group
-                        for the pool
-                      properties:
-                        blockDevices:
-                          items:
-                            description: CStorPoolInstanceBlockDevice contains the
-                              details of block devices that constitutes a raid group.
-                            properties:
-                              blockDeviceName:
-                                description: BlockDeviceName is the name of the block
-                                  device.
-                                type: string
-                              capacity:
-                                description: Capacity is the capacity of the block
-                                  device. It is system generated
-                                format: int64
-                                type: integer
-                              devLink:
-                                description: DevLink is the dev link for block devices
-                                type: string
-                            required:
-                            - blockDeviceName
-                            type: object
-                          type: array
-                      required:
-                      - blockDevices
-                      type: object
-                    type: array
-                  nodeSelector:
+                  limits:
                     additionalProperties:
-                      type: string
-                    description: NodeSelector is the labels that will be used to select
-                      a node for pool provisioning. Required field
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                     type: object
-                  poolConfig:
-                    description: PoolConfig is the default pool config that applies
-                      to the pool on node.
-                    properties:
-                      auxResources:
-                        description: AuxResources are the compute resources required
-                          by the cstor-pool pod side car containers.
-                        nullable: true
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                            type: object
-                        type: object
-                      compression:
-                        description: 'Compression to enable compression Optional --
-                          defaults to off Possible values : lz, off'
-                        type: string
-                      dataRaidGroupType:
-                        description: DataRaidGroupType is the  raid type.
-                        type: string
-                      priorityClassName:
-                        description: PriorityClassName if specified applies to this
-                          pool pod If left empty, DefaultPriorityClassName is applied.
-                          (See CStorPoolClusterSpec.DefaultPriorityClassName) If both
-                          are empty, not priority class is applied.
-                        nullable: true
-                        type: string
-                      resources:
-                        description: Resources are the compute resources required
-                          by the cstor-pool container.
-                        nullable: true
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                            type: object
-                        type: object
-                      roThresholdLimit:
-                        description: 'ROThresholdLimit is threshold(percentage base)
-                          limit for pool read only mode. If ROThresholdLimit(%) amount
-                          of pool storage is reached then pool will set to readonly.
-                          NOTE: 1. If ROThresholdLimit is set to 100 then entire    pool
-                          storage will be used by default it will be set to 85%. 2.
-                          ROThresholdLimit value will be 0 <= ROThresholdLimit <=
-                          100.'
-                        nullable: true
-                        type: integer
-                      thickProvision:
-                        description: ThickProvision to enable thick provisioning Optional
-                          -- defaults to false
-                        type: boolean
-                      tolerations:
-                        description: Tolerations, if specified, the pool pod's tolerations.
-                        items:
-                          description: The pod this Toleration is attached to tolerates
-                            any taint that matches the triple <key,value,effect> using
-                            the matching operator <operator>.
-                          properties:
-                            effect:
-                              description: Effect indicates the taint effect to match.
-                                Empty means match all taint effects. When specified,
-                                allowed values are NoSchedule, PreferNoSchedule and
-                                NoExecute.
-                              type: string
-                            key:
-                              description: Key is the taint key that the toleration
-                                applies to. Empty means match all taint keys. If the
-                                key is empty, operator must be Exists; this combination
-                                means to match all values and all keys.
-                              type: string
-                            operator:
-                              description: Operator represents a key's relationship
-                                to the value. Valid operators are Exists and Equal.
-                                Defaults to Equal. Exists is equivalent to wildcard
-                                for value, so that a pod can tolerate all taints of
-                                a particular category.
-                              type: string
-                            tolerationSeconds:
-                              description: TolerationSeconds represents the period
-                                of time the toleration (which must be of effect NoExecute,
-                                otherwise this field is ignored) tolerates the taint.
-                                By default, it is not set, which means tolerate the
-                                taint forever (do not evict). Zero and negative values
-                                will be treated as 0 (evict immediately) by the system.
-                              format: int64
-                              type: integer
-                            value:
-                              description: Value is the taint value the toleration
-                                matches to. If the operator is Exists, the value should
-                                be empty, otherwise just a regular string.
-                              type: string
-                          type: object
-                        nullable: true
-                        type: array
-                      writeCacheGroupType:
-                        description: WriteCacheGroupType is the write cache raid type.
-                        type: string
-                    required:
-                    - dataRaidGroupType
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                     type: object
-                  writeCacheRaidGroups:
-                    description: WriteCacheRaidGroups is the write cache raid group.
-                    items:
-                      description: RaidGroup contains the details of a raid group
-                        for the pool
+                type: object
+              pools:
+                description: Pools is the spec for pools for various nodes where it
+                  should be created.
+                items:
+                  description: PoolSpec is the spec for pool on node where it should
+                    be created.
+                  properties:
+                    dataRaidGroups:
+                      description: DataRaidGroups is the raid group configuration
+                        for the given pool.
+                      items:
+                        description: RaidGroup contains the details of a raid group
+                          for the pool
+                        properties:
+                          blockDevices:
+                            items:
+                              description: CStorPoolInstanceBlockDevice contains the
+                                details of block devices that constitutes a raid group.
+                              properties:
+                                blockDeviceName:
+                                  description: BlockDeviceName is the name of the
+                                    block device.
+                                  type: string
+                                capacity:
+                                  description: Capacity is the capacity of the block
+                                    device. It is system generated
+                                  format: int64
+                                  type: integer
+                                devLink:
+                                  description: DevLink is the dev link for block devices
+                                  type: string
+                              required:
+                              - blockDeviceName
+                              type: object
+                            type: array
+                        required:
+                        - blockDevices
+                        type: object
+                      type: array
+                    nodeSelector:
+                      additionalProperties:
+                        type: string
+                      description: NodeSelector is the labels that will be used to
+                        select a node for pool provisioning. Required field
+                      type: object
+                    poolConfig:
+                      description: PoolConfig is the default pool config that applies
+                        to the pool on node.
                       properties:
-                        blockDevices:
+                        auxResources:
+                          description: AuxResources are the compute resources required
+                            by the cstor-pool pod side car containers.
+                          nullable: true
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        compression:
+                          description: 'Compression to enable compression Optional
+                            -- defaults to off Possible values : lz, off'
+                          type: string
+                        dataRaidGroupType:
+                          description: DataRaidGroupType is the  raid type.
+                          type: string
+                        priorityClassName:
+                          description: PriorityClassName if specified applies to this
+                            pool pod If left empty, DefaultPriorityClassName is applied.
+                            (See CStorPoolClusterSpec.DefaultPriorityClassName) If
+                            both are empty, not priority class is applied.
+                          nullable: true
+                          type: string
+                        resources:
+                          description: Resources are the compute resources required
+                            by the cstor-pool container.
+                          nullable: true
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        roThresholdLimit:
+                          description: 'ROThresholdLimit is threshold(percentage base)
+                            limit for pool read only mode. If ROThresholdLimit(%)
+                            amount of pool storage is reached then pool will set to
+                            readonly. NOTE: 1. If ROThresholdLimit is set to 100 then
+                            entire    pool storage will be used by default it will
+                            be set to 85%. 2. ROThresholdLimit value will be 0 <=
+                            ROThresholdLimit <= 100.'
+                          nullable: true
+                          type: integer
+                        thickProvision:
+                          description: ThickProvision to enable thick provisioning
+                            Optional -- defaults to false
+                          type: boolean
+                        tolerations:
+                          description: Tolerations, if specified, the pool pod's tolerations.
                           items:
-                            description: CStorPoolInstanceBlockDevice contains the
-                              details of block devices that constitutes a raid group.
+                            description: The pod this Toleration is attached to tolerates
+                              any taint that matches the triple <key,value,effect>
+                              using the matching operator <operator>.
                             properties:
-                              blockDeviceName:
-                                description: BlockDeviceName is the name of the block
-                                  device.
+                              effect:
+                                description: Effect indicates the taint effect to
+                                  match. Empty means match all taint effects. When
+                                  specified, allowed values are NoSchedule, PreferNoSchedule
+                                  and NoExecute.
                                 type: string
-                              capacity:
-                                description: Capacity is the capacity of the block
-                                  device. It is system generated
+                              key:
+                                description: Key is the taint key that the toleration
+                                  applies to. Empty means match all taint keys. If
+                                  the key is empty, operator must be Exists; this
+                                  combination means to match all values and all keys.
+                                type: string
+                              operator:
+                                description: Operator represents a key's relationship
+                                  to the value. Valid operators are Exists and Equal.
+                                  Defaults to Equal. Exists is equivalent to wildcard
+                                  for value, so that a pod can tolerate all taints
+                                  of a particular category.
+                                type: string
+                              tolerationSeconds:
+                                description: TolerationSeconds represents the period
+                                  of time the toleration (which must be of effect
+                                  NoExecute, otherwise this field is ignored) tolerates
+                                  the taint. By default, it is not set, which means
+                                  tolerate the taint forever (do not evict). Zero
+                                  and negative values will be treated as 0 (evict
+                                  immediately) by the system.
                                 format: int64
                                 type: integer
-                              devLink:
-                                description: DevLink is the dev link for block devices
+                              value:
+                                description: Value is the taint value the toleration
+                                  matches to. If the operator is Exists, the value
+                                  should be empty, otherwise just a regular string.
                                 type: string
-                            required:
-                            - blockDeviceName
                             type: object
+                          nullable: true
                           type: array
+                        writeCacheGroupType:
+                          description: WriteCacheGroupType is the write cache raid
+                            type.
+                          type: string
                       required:
-                      - blockDevices
+                      - dataRaidGroupType
                       type: object
-                    nullable: true
-                    type: array
-                required:
-                - dataRaidGroups
-                - nodeSelector
-                type: object
-              type: array
-            priorityClassName:
-              description: DefaultPriorityClassName if specified applies to all the
-                pool pods in the pool spec if the priorityClass at the pool level
-                is not specified.
-              type: string
-            resources:
-              description: DefaultResources are the compute resources required by
-                the cstor-pool container. If the resources at PoolConfig is not specified,
-                this is written to CSPI PoolConfig.
-              nullable: true
-              properties:
-                limits:
-                  additionalProperties:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  description: 'Limits describes the maximum amount of compute resources
-                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    writeCacheRaidGroups:
+                      description: WriteCacheRaidGroups is the write cache raid group.
+                      items:
+                        description: RaidGroup contains the details of a raid group
+                          for the pool
+                        properties:
+                          blockDevices:
+                            items:
+                              description: CStorPoolInstanceBlockDevice contains the
+                                details of block devices that constitutes a raid group.
+                              properties:
+                                blockDeviceName:
+                                  description: BlockDeviceName is the name of the
+                                    block device.
+                                  type: string
+                                capacity:
+                                  description: Capacity is the capacity of the block
+                                    device. It is system generated
+                                  format: int64
+                                  type: integer
+                                devLink:
+                                  description: DevLink is the dev link for block devices
+                                  type: string
+                              required:
+                              - blockDeviceName
+                              type: object
+                            type: array
+                        required:
+                        - blockDevices
+                        type: object
+                      nullable: true
+                      type: array
+                  required:
+                  - dataRaidGroups
+                  - nodeSelector
                   type: object
-                requests:
-                  additionalProperties:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  description: 'Requests describes the minimum amount of compute resources
-                    required. If Requests is omitted for a container, it defaults
-                    to Limits if that is explicitly specified, otherwise to an implementation-defined
-                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                  type: object
-              type: object
-            tolerations:
-              description: Tolerations, if specified, are the pool pod's tolerations
-                If tolerations at PoolConfig is empty, this is written to CSPI PoolConfig.
-              items:
-                description: The pod this Toleration is attached to tolerates any
-                  taint that matches the triple <key,value,effect> using the matching
-                  operator <operator>.
+                type: array
+              priorityClassName:
+                description: DefaultPriorityClassName if specified applies to all
+                  the pool pods in the pool spec if the priorityClass at the pool
+                  level is not specified.
+                type: string
+              resources:
+                description: DefaultResources are the compute resources required by
+                  the cstor-pool container. If the resources at PoolConfig is not
+                  specified, this is written to CSPI PoolConfig.
+                nullable: true
                 properties:
-                  effect:
-                    description: Effect indicates the taint effect to match. Empty
-                      means match all taint effects. When specified, allowed values
-                      are NoSchedule, PreferNoSchedule and NoExecute.
-                    type: string
-                  key:
-                    description: Key is the taint key that the toleration applies
-                      to. Empty means match all taint keys. If the key is empty, operator
-                      must be Exists; this combination means to match all values and
-                      all keys.
-                    type: string
-                  operator:
-                    description: Operator represents a key's relationship to the value.
-                      Valid operators are Exists and Equal. Defaults to Equal. Exists
-                      is equivalent to wildcard for value, so that a pod can tolerate
-                      all taints of a particular category.
-                    type: string
-                  tolerationSeconds:
-                    description: TolerationSeconds represents the period of time the
-                      toleration (which must be of effect NoExecute, otherwise this
-                      field is ignored) tolerates the taint. By default, it is not
-                      set, which means tolerate the taint forever (do not evict).
-                      Zero and negative values will be treated as 0 (evict immediately)
-                      by the system.
-                    format: int64
-                    type: integer
-                  value:
-                    description: Value is the taint value the toleration matches to.
-                      If the operator is Exists, the value should be empty, otherwise
-                      just a regular string.
-                    type: string
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
                 type: object
-              nullable: true
-              type: array
-          type: object
-        status:
-          description: CStorPoolClusterStatus represents the latest available observations
-            of a CSPC's current state.
-          properties:
-            conditions:
-              description: Current state of CSPC.
-              items:
-                description: CStorPoolClusterCondition describes the state of a CSPC
-                  at a certain point.
+              tolerations:
+                description: Tolerations, if specified, are the pool pod's tolerations
+                  If tolerations at PoolConfig is empty, this is written to CSPI PoolConfig.
+                items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
+                  properties:
+                    effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
+                      type: string
+                  type: object
+                nullable: true
+                type: array
+            type: object
+          status:
+            description: CStorPoolClusterStatus represents the latest available observations
+              of a CSPC's current state.
+            properties:
+              conditions:
+                description: Current state of CSPC.
+                items:
+                  description: CStorPoolClusterCondition describes the state of a
+                    CSPC at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    lastUpdateTime:
+                      description: The last time this condition was updated.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of CSPC condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                nullable: true
+                type: array
+              desiredInstances:
+                description: DesiredInstances is the number of CSPI(s) that should
+                  be provisioned.
+                format: int32
+                nullable: true
+                type: integer
+              healthyInstances:
+                description: HealthyInstances is the number of CSPI(s) that are healthy.
+                format: int32
+                nullable: true
+                type: integer
+              provisionedInstances:
+                description: ProvisionedInstances is the the number of CSPI present
+                  at the current state.
+                format: int32
+                nullable: true
+                type: integer
+            type: object
+          versionDetails:
+            description: VersionDetails provides the details for upgrade
+            properties:
+              autoUpgrade:
+                description: If AutoUpgrade is set to true then the resource is upgraded
+                  automatically without any manual steps
+                type: boolean
+              desired:
+                description: Desired is the version that we want to upgrade or the
+                  control plane version
+                type: string
+              status:
+                description: Status gives the status of reconciliation triggered when
+                  the desired and current version are not same
                 properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
-                    format: date-time
+                  current:
+                    description: Current is the version of resource
                     type: string
+                  dependentsUpgraded:
+                    description: DependentsUpgraded gives the details whether all
+                      children of a resource are upgraded to desired version or not
+                    type: boolean
                   lastUpdateTime:
-                    description: The last time this condition was updated.
+                    description: LastUpdateTime is the time the status was last  updated
                     format: date-time
+                    nullable: true
                     type: string
                   message:
-                    description: A human readable message indicating details about
-                      the transition.
+                    description: Message is a human readable message if some error
+                      occurs
                     type: string
                   reason:
-                    description: The reason for the condition's last transition.
+                    description: Reason is the actual reason for the error state
                     type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
+                  state:
+                    description: State is the state of reconciliation
                     type: string
-                  type:
-                    description: Type of CSPC condition.
-                    type: string
-                required:
-                - status
-                - type
                 type: object
-              nullable: true
-              type: array
-            desiredInstances:
-              description: DesiredInstances is the number of CSPI(s) that should be
-                provisioned.
-              format: int32
-              nullable: true
-              type: integer
-            healthyInstances:
-              description: HealthyInstances is the number of CSPI(s) that are healthy.
-              format: int32
-              nullable: true
-              type: integer
-            provisionedInstances:
-              description: ProvisionedInstances is the the number of CSPI present
-                at the current state.
-              format: int32
-              nullable: true
-              type: integer
-          type: object
-        versionDetails:
-          description: VersionDetails provides the details for upgrade
-          properties:
-            autoUpgrade:
-              description: If AutoUpgrade is set to true then the resource is upgraded
-                automatically without any manual steps
-              type: boolean
-            desired:
-              description: Desired is the version that we want to upgrade or the control
-                plane version
-              type: string
-            status:
-              description: Status gives the status of reconciliation triggered when
-                the desired and current version are not same
-              properties:
-                current:
-                  description: Current is the version of resource
-                  type: string
-                dependentsUpgraded:
-                  description: DependentsUpgraded gives the details whether all children
-                    of a resource are upgraded to desired version or not
-                  type: boolean
-                lastUpdateTime:
-                  description: LastUpdateTime is the time the status was last  updated
-                  format: date-time
-                  nullable: true
-                  type: string
-                message:
-                  description: Message is a human readable message if some error occurs
-                  type: string
-                reason:
-                  description: Reason is the actual reason for the error state
-                  type: string
-                state:
-                  description: State is the state of reconciliation
-                  type: string
-              type: object
-          type: object
-      required:
-      - spec
-      type: object
-  version: v1
-  versions:
-  - name: v1
+            type: object
+        required:
+        - spec
+        type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/crds/bases/cstor.openebs.io_cstorpoolinstances.yaml
+++ b/config/crds/bases/cstor.openebs.io_cstorpoolinstances.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: cstorpoolinstances.cstor.openebs.io
 spec:

--- a/config/crds/bases/cstor.openebs.io_cstorpoolinstances.yaml
+++ b/config/crds/bases/cstor.openebs.io_cstorpoolinstances.yaml
@@ -1,57 +1,13 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.9
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: cstorpoolinstances.cstor.openebs.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.hostName
-    description: Host name where cstorpool instances scheduled
-    name: HostName
-    type: string
-  - JSONPath: .status.capacity.used
-    description: The amount of storage space within the pool that has been physically
-      allocated
-    name: Allocated
-    priority: 1
-    type: string
-  - JSONPath: .status.capacity.free
-    description: The amount of usable free space available in the pool
-    name: Free
-    type: string
-  - JSONPath: .status.capacity.total
-    description: Total amount of usable space in pool
-    name: Capacity
-    type: string
-  - JSONPath: .status.readOnly
-    description: Identifies the pool read only mode
-    name: ReadOnly
-    type: boolean
-  - JSONPath: .status.provisionedReplicas
-    description: Represents no.of replicas present in the pool
-    name: ProvisionedReplicas
-    type: integer
-  - JSONPath: .status.healthyReplicas
-    description: Represents no.of healthy replicas present in the pool
-    name: HealthyReplicas
-    type: integer
-  - JSONPath: .spec.poolConfig.dataRaidGroupType
-    description: Represents the type of the storage pool
-    name: Type
-    priority: 1
-    type: string
-  - JSONPath: .status.phase
-    description: Identifies the current health of the pool
-    name: Status
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: Age of CStorPoolInstance
-    name: Age
-    type: date
   group: cstor.openebs.io
   names:
     kind: CStorPoolInstance
@@ -60,391 +16,439 @@ spec:
     shortNames:
     - cspi
     singular: cstorpoolinstance
-  preserveUnknownFields: false
   scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: CStorPoolInstance describes a cstor pool instance resource.
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: Spec is the specification of the cstorpoolinstance resource.
-          properties:
-            dataRaidGroups:
-              description: DataRaidGroups is the raid group configuration for the
-                given pool.
-              items:
-                description: RaidGroup contains the details of a raid group for the
-                  pool
-                properties:
-                  blockDevices:
-                    items:
-                      description: CStorPoolInstanceBlockDevice contains the details
-                        of block devices that constitutes a raid group.
-                      properties:
-                        blockDeviceName:
-                          description: BlockDeviceName is the name of the block device.
-                          type: string
-                        capacity:
-                          description: Capacity is the capacity of the block device.
-                            It is system generated
-                          format: int64
-                          type: integer
-                        devLink:
-                          description: DevLink is the dev link for block devices
-                          type: string
-                      required:
-                      - blockDeviceName
-                      type: object
-                    type: array
-                required:
-                - blockDevices
-                type: object
-              type: array
-            hostName:
-              description: HostName is the name of kubernetes node where the pool
-                should be created.
-              type: string
-            nodeSelector:
-              additionalProperties:
-                type: string
-              description: NodeSelector is the labels that will be used to select
-                a node for pool provisioning. Required field
-              type: object
-            poolConfig:
-              description: PoolConfig is the default pool config that applies to the
-                pool on node.
-              properties:
-                auxResources:
-                  description: AuxResources are the compute resources required by
-                    the cstor-pool pod side car containers.
-                  nullable: true
+  versions:
+  - additionalPrinterColumns:
+    - description: Host name where cstorpool instances scheduled
+      jsonPath: .spec.hostName
+      name: HostName
+      type: string
+    - description: The amount of storage space within the pool that has been physically
+        allocated
+      jsonPath: .status.capacity.used
+      name: Allocated
+      priority: 1
+      type: string
+    - description: The amount of usable free space available in the pool
+      jsonPath: .status.capacity.free
+      name: Free
+      type: string
+    - description: Total amount of usable space in pool
+      jsonPath: .status.capacity.total
+      name: Capacity
+      type: string
+    - description: Identifies the pool read only mode
+      jsonPath: .status.readOnly
+      name: ReadOnly
+      type: boolean
+    - description: Represents no.of replicas present in the pool
+      jsonPath: .status.provisionedReplicas
+      name: ProvisionedReplicas
+      type: integer
+    - description: Represents no.of healthy replicas present in the pool
+      jsonPath: .status.healthyReplicas
+      name: HealthyReplicas
+      type: integer
+    - description: Represents the type of the storage pool
+      jsonPath: .spec.poolConfig.dataRaidGroupType
+      name: Type
+      priority: 1
+      type: string
+    - description: Identifies the current health of the pool
+      jsonPath: .status.phase
+      name: Status
+      type: string
+    - description: Age of CStorPoolInstance
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: CStorPoolInstance describes a cstor pool instance resource.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec is the specification of the cstorpoolinstance resource.
+            properties:
+              dataRaidGroups:
+                description: DataRaidGroups is the raid group configuration for the
+                  given pool.
+                items:
+                  description: RaidGroup contains the details of a raid group for
+                    the pool
                   properties:
-                    limits:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute
-                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                    requests:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Requests describes the minimum amount of compute
-                        resources required. If Requests is omitted for a container,
-                        it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                  type: object
-                compression:
-                  description: 'Compression to enable compression Optional -- defaults
-                    to off Possible values : lz, off'
-                  type: string
-                dataRaidGroupType:
-                  description: DataRaidGroupType is the  raid type.
-                  type: string
-                priorityClassName:
-                  description: PriorityClassName if specified applies to this pool
-                    pod If left empty, DefaultPriorityClassName is applied. (See CStorPoolClusterSpec.DefaultPriorityClassName)
-                    If both are empty, not priority class is applied.
-                  nullable: true
-                  type: string
-                resources:
-                  description: Resources are the compute resources required by the
-                    cstor-pool container.
-                  nullable: true
-                  properties:
-                    limits:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute
-                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                    requests:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Requests describes the minimum amount of compute
-                        resources required. If Requests is omitted for a container,
-                        it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                  type: object
-                roThresholdLimit:
-                  description: 'ROThresholdLimit is threshold(percentage base) limit
-                    for pool read only mode. If ROThresholdLimit(%) amount of pool
-                    storage is reached then pool will set to readonly. NOTE: 1. If
-                    ROThresholdLimit is set to 100 then entire    pool storage will
-                    be used by default it will be set to 85%. 2. ROThresholdLimit
-                    value will be 0 <= ROThresholdLimit <= 100.'
-                  nullable: true
-                  type: integer
-                thickProvision:
-                  description: ThickProvision to enable thick provisioning Optional
-                    -- defaults to false
-                  type: boolean
-                tolerations:
-                  description: Tolerations, if specified, the pool pod's tolerations.
-                  items:
-                    description: The pod this Toleration is attached to tolerates
-                      any taint that matches the triple <key,value,effect> using the
-                      matching operator <operator>.
-                    properties:
-                      effect:
-                        description: Effect indicates the taint effect to match. Empty
-                          means match all taint effects. When specified, allowed values
-                          are NoSchedule, PreferNoSchedule and NoExecute.
-                        type: string
-                      key:
-                        description: Key is the taint key that the toleration applies
-                          to. Empty means match all taint keys. If the key is empty,
-                          operator must be Exists; this combination means to match
-                          all values and all keys.
-                        type: string
-                      operator:
-                        description: Operator represents a key's relationship to the
-                          value. Valid operators are Exists and Equal. Defaults to
-                          Equal. Exists is equivalent to wildcard for value, so that
-                          a pod can tolerate all taints of a particular category.
-                        type: string
-                      tolerationSeconds:
-                        description: TolerationSeconds represents the period of time
-                          the toleration (which must be of effect NoExecute, otherwise
-                          this field is ignored) tolerates the taint. By default,
-                          it is not set, which means tolerate the taint forever (do
-                          not evict). Zero and negative values will be treated as
-                          0 (evict immediately) by the system.
-                        format: int64
-                        type: integer
-                      value:
-                        description: Value is the taint value the toleration matches
-                          to. If the operator is Exists, the value should be empty,
-                          otherwise just a regular string.
-                        type: string
-                    type: object
-                  nullable: true
-                  type: array
-                writeCacheGroupType:
-                  description: WriteCacheGroupType is the write cache raid type.
-                  type: string
-              required:
-              - dataRaidGroupType
-              type: object
-            writeCacheRaidGroups:
-              description: WriteCacheRaidGroups is the write cache raid group.
-              items:
-                description: RaidGroup contains the details of a raid group for the
-                  pool
-                properties:
-                  blockDevices:
-                    items:
-                      description: CStorPoolInstanceBlockDevice contains the details
-                        of block devices that constitutes a raid group.
-                      properties:
-                        blockDeviceName:
-                          description: BlockDeviceName is the name of the block device.
-                          type: string
-                        capacity:
-                          description: Capacity is the capacity of the block device.
-                            It is system generated
-                          format: int64
-                          type: integer
-                        devLink:
-                          description: DevLink is the dev link for block devices
-                          type: string
-                      required:
-                      - blockDeviceName
-                      type: object
-                    type: array
-                required:
-                - blockDevices
-                type: object
-              nullable: true
-              type: array
-          required:
-          - dataRaidGroups
-          - nodeSelector
-          type: object
-        status:
-          description: Status is the possible statuses of the cstorpoolinstance resource.
-          properties:
-            capacity:
-              description: Capacity describes the capacity details of a cstor pool
-              properties:
-                free:
-                  anyOf:
-                  - type: integer
-                  - type: string
-                  description: Amount of usable space in the pool after excluding
-                    metadata and raid parity
-                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                  x-kubernetes-int-or-string: true
-                total:
-                  anyOf:
-                  - type: integer
-                  - type: string
-                  description: Sum of usable capacity in all the data raidgroups
-                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                  x-kubernetes-int-or-string: true
-                used:
-                  anyOf:
-                  - type: integer
-                  - type: string
-                  description: Amount of physical data (and its metadata) written
-                    to pool after applying compression, etc..,
-                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                  x-kubernetes-int-or-string: true
-                zfs:
-                  description: ZFSCapacityAttributes contains advanced information
-                    about pool capacity details
-                  properties:
-                    logicalUsed:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      description: LogicalUsed is the amount of space that is "logically"
-                        consumed by this pool and all its descendents. The logical
-                        space ignores the effect of the compression and copies properties,
-                        giving a quantity closer to the amount of data that applications
-                        see. However, it does include space consumed by metadata.
-                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      x-kubernetes-int-or-string: true
+                    blockDevices:
+                      items:
+                        description: CStorPoolInstanceBlockDevice contains the details
+                          of block devices that constitutes a raid group.
+                        properties:
+                          blockDeviceName:
+                            description: BlockDeviceName is the name of the block
+                              device.
+                            type: string
+                          capacity:
+                            description: Capacity is the capacity of the block device.
+                              It is system generated
+                            format: int64
+                            type: integer
+                          devLink:
+                            description: DevLink is the dev link for block devices
+                            type: string
+                        required:
+                        - blockDeviceName
+                        type: object
+                      type: array
                   required:
-                  - logicalUsed
+                  - blockDevices
                   type: object
-              required:
-              - free
-              - total
-              - used
-              - zfs
-              type: object
-            conditions:
-              description: Current state of CSPI with details.
-              items:
-                description: CSPIConditionType describes the state of a CSPI at a
-                  certain point.
+                type: array
+              hostName:
+                description: HostName is the name of kubernetes node where the pool
+                  should be created.
+                type: string
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector is the labels that will be used to select
+                  a node for pool provisioning. Required field
+                type: object
+              poolConfig:
+                description: PoolConfig is the default pool config that applies to
+                  the pool on node.
                 properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
-                    format: date-time
+                  auxResources:
+                    description: AuxResources are the compute resources required by
+                      the cstor-pool pod side car containers.
+                    nullable: true
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  compression:
+                    description: 'Compression to enable compression Optional -- defaults
+                      to off Possible values : lz, off'
                     type: string
+                  dataRaidGroupType:
+                    description: DataRaidGroupType is the  raid type.
+                    type: string
+                  priorityClassName:
+                    description: PriorityClassName if specified applies to this pool
+                      pod If left empty, DefaultPriorityClassName is applied. (See
+                      CStorPoolClusterSpec.DefaultPriorityClassName) If both are empty,
+                      not priority class is applied.
+                    nullable: true
+                    type: string
+                  resources:
+                    description: Resources are the compute resources required by the
+                      cstor-pool container.
+                    nullable: true
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  roThresholdLimit:
+                    description: 'ROThresholdLimit is threshold(percentage base) limit
+                      for pool read only mode. If ROThresholdLimit(%) amount of pool
+                      storage is reached then pool will set to readonly. NOTE: 1.
+                      If ROThresholdLimit is set to 100 then entire    pool storage
+                      will be used by default it will be set to 85%. 2. ROThresholdLimit
+                      value will be 0 <= ROThresholdLimit <= 100.'
+                    nullable: true
+                    type: integer
+                  thickProvision:
+                    description: ThickProvision to enable thick provisioning Optional
+                      -- defaults to false
+                    type: boolean
+                  tolerations:
+                    description: Tolerations, if specified, the pool pod's tolerations.
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using
+                        the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match.
+                            Empty means match all taint effects. When specified, allowed
+                            values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to
+                            the value. Valid operators are Exists and Equal. Defaults
+                            to Equal. Exists is equivalent to wildcard for value,
+                            so that a pod can tolerate all taints of a particular
+                            category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of
+                            time the toleration (which must be of effect NoExecute,
+                            otherwise this field is ignored) tolerates the taint.
+                            By default, it is not set, which means tolerate the taint
+                            forever (do not evict). Zero and negative values will
+                            be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    nullable: true
+                    type: array
+                  writeCacheGroupType:
+                    description: WriteCacheGroupType is the write cache raid type.
+                    type: string
+                required:
+                - dataRaidGroupType
+                type: object
+              writeCacheRaidGroups:
+                description: WriteCacheRaidGroups is the write cache raid group.
+                items:
+                  description: RaidGroup contains the details of a raid group for
+                    the pool
+                  properties:
+                    blockDevices:
+                      items:
+                        description: CStorPoolInstanceBlockDevice contains the details
+                          of block devices that constitutes a raid group.
+                        properties:
+                          blockDeviceName:
+                            description: BlockDeviceName is the name of the block
+                              device.
+                            type: string
+                          capacity:
+                            description: Capacity is the capacity of the block device.
+                              It is system generated
+                            format: int64
+                            type: integer
+                          devLink:
+                            description: DevLink is the dev link for block devices
+                            type: string
+                        required:
+                        - blockDeviceName
+                        type: object
+                      type: array
+                  required:
+                  - blockDevices
+                  type: object
+                nullable: true
+                type: array
+            required:
+            - dataRaidGroups
+            - nodeSelector
+            type: object
+          status:
+            description: Status is the possible statuses of the cstorpoolinstance
+              resource.
+            properties:
+              capacity:
+                description: Capacity describes the capacity details of a cstor pool
+                properties:
+                  free:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: Amount of usable space in the pool after excluding
+                      metadata and raid parity
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  total:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: Sum of usable capacity in all the data raidgroups
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  used:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: Amount of physical data (and its metadata) written
+                      to pool after applying compression, etc..,
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  zfs:
+                    description: ZFSCapacityAttributes contains advanced information
+                      about pool capacity details
+                    properties:
+                      logicalUsed:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: LogicalUsed is the amount of space that is "logically"
+                          consumed by this pool and all its descendents. The logical
+                          space ignores the effect of the compression and copies properties,
+                          giving a quantity closer to the amount of data that applications
+                          see. However, it does include space consumed by metadata.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                    required:
+                    - logicalUsed
+                    type: object
+                required:
+                - free
+                - total
+                - used
+                - zfs
+                type: object
+              conditions:
+                description: Current state of CSPI with details.
+                items:
+                  description: CSPIConditionType describes the state of a CSPI at
+                    a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    lastUpdateTime:
+                      description: The last time this condition was updated.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of CSPC condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              healthyReplicas:
+                description: HealthyReplicas describes the total count of healthy
+                  Volume Replicas in the cstor pool
+                format: int32
+                type: integer
+              phase:
+                description: ' The phase of a CStorPool is a simple, high-level summary
+                  of the pool state on the  node.'
+                type: string
+              provisionedReplicas:
+                description: ProvisionedReplicas describes the total count of Volume
+                  Replicas present in the cstor pool
+                format: int32
+                type: integer
+              readOnly:
+                description: ReadOnly if pool is readOnly or not
+                type: boolean
+            required:
+            - healthyReplicas
+            - provisionedReplicas
+            - readOnly
+            type: object
+          versionDetails:
+            description: VersionDetails is the openebs version.
+            properties:
+              autoUpgrade:
+                description: If AutoUpgrade is set to true then the resource is upgraded
+                  automatically without any manual steps
+                type: boolean
+              desired:
+                description: Desired is the version that we want to upgrade or the
+                  control plane version
+                type: string
+              status:
+                description: Status gives the status of reconciliation triggered when
+                  the desired and current version are not same
+                properties:
+                  current:
+                    description: Current is the version of resource
+                    type: string
+                  dependentsUpgraded:
+                    description: DependentsUpgraded gives the details whether all
+                      children of a resource are upgraded to desired version or not
+                    type: boolean
                   lastUpdateTime:
-                    description: The last time this condition was updated.
+                    description: LastUpdateTime is the time the status was last  updated
                     format: date-time
+                    nullable: true
                     type: string
                   message:
-                    description: A human readable message indicating details about
-                      the transition.
+                    description: Message is a human readable message if some error
+                      occurs
                     type: string
                   reason:
-                    description: The reason for the condition's last transition.
+                    description: Reason is the actual reason for the error state
                     type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
+                  state:
+                    description: State is the state of reconciliation
                     type: string
-                  type:
-                    description: Type of CSPC condition.
-                    type: string
-                required:
-                - status
-                - type
                 type: object
-              type: array
-            healthyReplicas:
-              description: HealthyReplicas describes the total count of healthy Volume
-                Replicas in the cstor pool
-              format: int32
-              type: integer
-            phase:
-              description: ' The phase of a CStorPool is a simple, high-level summary
-                of the pool state on the  node.'
-              type: string
-            provisionedReplicas:
-              description: ProvisionedReplicas describes the total count of Volume
-                Replicas present in the cstor pool
-              format: int32
-              type: integer
-            readOnly:
-              description: ReadOnly if pool is readOnly or not
-              type: boolean
-          required:
-          - healthyReplicas
-          - provisionedReplicas
-          - readOnly
-          type: object
-        versionDetails:
-          description: VersionDetails is the openebs version.
-          properties:
-            autoUpgrade:
-              description: If AutoUpgrade is set to true then the resource is upgraded
-                automatically without any manual steps
-              type: boolean
-            desired:
-              description: Desired is the version that we want to upgrade or the control
-                plane version
-              type: string
-            status:
-              description: Status gives the status of reconciliation triggered when
-                the desired and current version are not same
-              properties:
-                current:
-                  description: Current is the version of resource
-                  type: string
-                dependentsUpgraded:
-                  description: DependentsUpgraded gives the details whether all children
-                    of a resource are upgraded to desired version or not
-                  type: boolean
-                lastUpdateTime:
-                  description: LastUpdateTime is the time the status was last  updated
-                  format: date-time
-                  nullable: true
-                  type: string
-                message:
-                  description: Message is a human readable message if some error occurs
-                  type: string
-                reason:
-                  description: Reason is the actual reason for the error state
-                  type: string
-                state:
-                  description: State is the state of reconciliation
-                  type: string
-              type: object
-          type: object
-      required:
-      - spec
-      type: object
-  version: v1
-  versions:
-  - name: v1
+            type: object
+        required:
+        - spec
+        type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/crds/bases/cstor.openebs.io_cstorrestores.yaml
+++ b/config/crds/bases/cstor.openebs.io_cstorrestores.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: cstorrestores.cstor.openebs.io
 spec:

--- a/config/crds/bases/cstor.openebs.io_cstorrestores.yaml
+++ b/config/crds/bases/cstor.openebs.io_cstorrestores.yaml
@@ -1,26 +1,13 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.9
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: cstorrestores.cstor.openebs.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.restoreName
-    description: Name of the snapshot which is restored
-    name: Backup
-    type: string
-  - JSONPath: .spec.volumeName
-    description: Volume on which restore is performed
-    name: Volume
-    type: string
-  - JSONPath: .status
-    description: Identifies the state of the restore
-    name: Status
-    type: string
   group: cstor.openebs.io
   names:
     kind: CStorRestore
@@ -29,79 +16,90 @@ spec:
     shortNames:
     - crestore
     singular: cstorrestore
-  preserveUnknownFields: false
   scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: CStorRestore describes a cstor restore resource created as a custom
-        resource
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: CStorRestoreSpec is the spec for a CStorRestore resource
-          properties:
-            localRestore:
-              description: Local defines whether restore is from local/remote
-              type: boolean
-            maxretrycount:
-              description: MaxRestoreRetryCount is the maximum number of attempt,
-                will be performed to restore
-              type: integer
-            restoreName:
-              description: RestoreName holds restore name
-              type: string
-            restoreSrc:
-              description: RestoreSrc can be ip:port in case of restore from remote
-                or volumeName in case of local restore
-              type: string
-            retrycount:
-              description: RetryCount represents the number of restore attempts performed
-                for the restore
-              type: integer
-            size:
-              anyOf:
-              - type: integer
-              - type: string
-              description: Size represents the size of a snapshot to restore
-              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-              x-kubernetes-int-or-string: true
-            storageClass:
-              description: StorageClass represents name of StorageClass of restore
-                volume
-              type: string
-            volumeName:
-              description: VolumeName is used to restore the data to corresponding
-                volume
-              type: string
-          required:
-          - restoreName
-          - restoreSrc
-          - volumeName
-          type: object
-        status:
-          description: CStorRestoreStatus is a string type that represents the status
-            of the restore
-          type: string
-      required:
-      - spec
-      type: object
-  version: v1
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: Name of the snapshot which is restored
+      jsonPath: .spec.restoreName
+      name: Backup
+      type: string
+    - description: Volume on which restore is performed
+      jsonPath: .spec.volumeName
+      name: Volume
+      type: string
+    - description: Identifies the state of the restore
+      jsonPath: .status
+      name: Status
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: CStorRestore describes a cstor restore resource created as a
+          custom resource
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CStorRestoreSpec is the spec for a CStorRestore resource
+            properties:
+              localRestore:
+                description: Local defines whether restore is from local/remote
+                type: boolean
+              maxretrycount:
+                description: MaxRestoreRetryCount is the maximum number of attempt,
+                  will be performed to restore
+                type: integer
+              restoreName:
+                description: RestoreName holds restore name
+                type: string
+              restoreSrc:
+                description: RestoreSrc can be ip:port in case of restore from remote
+                  or volumeName in case of local restore
+                type: string
+              retrycount:
+                description: RetryCount represents the number of restore attempts
+                  performed for the restore
+                type: integer
+              size:
+                anyOf:
+                - type: integer
+                - type: string
+                description: Size represents the size of a snapshot to restore
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+              storageClass:
+                description: StorageClass represents name of StorageClass of restore
+                  volume
+                type: string
+              volumeName:
+                description: VolumeName is used to restore the data to corresponding
+                  volume
+                type: string
+            required:
+            - restoreName
+            - restoreSrc
+            - volumeName
+            type: object
+          status:
+            description: CStorRestoreStatus is a string type that represents the status
+              of the restore
+            type: string
+        required:
+        - spec
+        type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/crds/bases/cstor.openebs.io_cstorvolumeconfigs.yaml
+++ b/config/crds/bases/cstor.openebs.io_cstorvolumeconfigs.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: cstorvolumeconfigs.cstor.openebs.io
 spec:

--- a/config/crds/bases/cstor.openebs.io_cstorvolumeconfigs.yaml
+++ b/config/crds/bases/cstor.openebs.io_cstorvolumeconfigs.yaml
@@ -1,26 +1,13 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.9
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: cstorvolumeconfigs.cstor.openebs.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.capacity.storage
-    description: Identifies the volume capacity
-    name: Capacity
-    type: string
-  - JSONPath: .status.phase
-    description: Identifies the volume provisioning status
-    name: Status
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: Age of CStorVolumeReplica
-    name: Age
-    type: date
   group: cstor.openebs.io
   names:
     kind: CStorVolumeConfig
@@ -29,606 +16,623 @@ spec:
     shortNames:
     - cvc
     singular: cstorvolumeconfig
-  preserveUnknownFields: false
   scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: CStorVolumeConfig describes a cstor volume config resource created
-        as custom resource. CStorVolumeConfig is a request for creating cstor volume
-        related resources like deployment, svc etc.
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        publish:
-          description: Publish contains info related to attachment of a volume to
-            a node. i.e. NodeId etc.
-          properties:
-            nodeId:
-              description: NodeID contains publish info related to attachment of a
-                volume to a node.
-              type: string
-          type: object
-        spec:
-          description: Spec defines a specification of a cstor volume config required
-            to provisione cstor volume resources
-          properties:
-            capacity:
-              additionalProperties:
-                anyOf:
-                - type: integer
-                - type: string
-                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                x-kubernetes-int-or-string: true
-              description: Capacity represents the actual resources of the underlying
-                cstor volume.
-              type: object
-            cstorVolumeRef:
-              description: CStorVolumeRef has the information about where CstorVolumeClaim
-                is created from.
-              properties:
-                apiVersion:
-                  description: API version of the referent.
-                  type: string
-                fieldPath:
-                  description: 'If referring to a piece of an object instead of an
-                    entire object, this string should contain a valid JSON/Go field
-                    access statement, such as desiredState.manifest.containers[2].
-                    For example, if the object reference is to a container within
-                    a pod, this would take on a value like: "spec.containers{name}"
-                    (where "name" refers to the name of the container that triggered
-                    the event) or if no container name is specified "spec.containers[2]"
-                    (container with index 2 in this pod). This syntax is chosen only
-                    to have some well-defined way of referencing a part of an object.
-                    TODO: this design is not final and this field is subject to change
-                    in the future.'
-                  type: string
-                kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                  type: string
-                namespace:
-                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                  type: string
-                resourceVersion:
-                  description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                  type: string
-                uid:
-                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                  type: string
-              type: object
-            cstorVolumeSource:
-              description: CStorVolumeSource contains the source volumeName@snapShotname
-                combaination.  This will be filled only if it is a clone creation.
-              type: string
-            policy:
-              description: Policy contains volume specific required policies target
-                and replicas
-              properties:
-                provision:
-                  description: replicaAffinity is set to true then volume replica
-                    resources need to be distributed across the pool instances
-                  properties:
-                    blockSize:
-                      description: BlockSize is the logical block size in multiple
-                        of 512 bytes BlockSize specifies the block size of the volume.
-                        The blocksize cannot be changed once the volume has been written,
-                        so it should be set at volume creation time. The default blocksize
-                        for volumes is 4 Kbytes. Any power of 2 from 512 bytes to
-                        128 Kbytes is valid.
-                      format: int32
-                      type: integer
-                    replicaAffinity:
-                      description: replicaAffinity is set to true then volume replica
-                        resources need to be distributed across the cstor pool instances
-                        based on the given topology
-                      type: boolean
-                  required:
-                  - replicaAffinity
-                  type: object
-                replica:
-                  description: ReplicaSpec represents configuration related to replicas
-                    resources
-                  properties:
-                    compression:
-                      description: The zle compression algorithm compresses runs of
-                        zeros.
-                      type: string
-                    zvolWorkers:
-                      description: IOWorkers represents number of threads that executes
-                        client IOs
-                      type: string
-                  type: object
-                replicaPoolInfo:
-                  description: 'ReplicaPoolInfo holds the pool information of volume
-                    replicas. Ex: If volume is provisioned on which CStor pool volume
-                    replicas exist'
-                  items:
-                    description: ReplicaPoolInfo represents the pool information of
-                      volume replica
-                    properties:
-                      poolName:
-                        description: PoolName represents the pool name where volume
-                          replica exists
-                        type: string
-                    required:
-                    - poolName
-                    type: object
-                  type: array
-                target:
-                  description: TargetSpec represents configuration related to cstor
-                    target and its resources
-                  properties:
-                    affinity:
-                      description: PodAffinity if specified, are the target pod's
-                        affinities
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods
-                            to nodes that satisfy the affinity expressions specified
-                            by this field, but it may choose a node that violates
-                            one or more of the expressions. The node that is most
-                            preferred is the one with the greatest sum of weights,
-                            i.e. for each node that meets all of the scheduling requirements
-                            (resource request, requiredDuringScheduling affinity expressions,
-                            etc.), compute a sum by iterating through the elements
-                            of this field and adding "weight" to the sum if the node
-                            has pods which matches the corresponding podAffinityTerm;
-                            the node(s) with the highest sum are the most preferred.
-                          items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm
-                              fields are added per-node to find the most preferred
-                              node(s)
-                            properties:
-                              podAffinityTerm:
-                                description: Required. A pod affinity term, associated
-                                  with the corresponding weight.
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies which namespaces
-                                      the labelSelector applies to (matches against);
-                                      null or empty list means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified
-                                      namespaces, where co-located is defined as running
-                                      on a node whose value of the label with key
-                                      topologyKey matches that of any node on which
-                                      any of the selected pods is running. Empty topologyKey
-                                      is not allowed.
-                                    type: string
-                                required:
-                                - topologyKey
-                                type: object
-                              weight:
-                                description: weight associated with matching the corresponding
-                                  podAffinityTerm, in the range 1-100.
-                                format: int32
-                                type: integer
-                            required:
-                            - podAffinityTerm
-                            - weight
-                            type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this
-                            field are not met at scheduling time, the pod will not
-                            be scheduled onto the node. If the affinity requirements
-                            specified by this field cease to be met at some point
-                            during pod execution (e.g. due to a pod label update),
-                            the system may or may not try to eventually evict the
-                            pod from its node. When there are multiple elements, the
-                            lists of nodes corresponding to each podAffinityTerm are
-                            intersected, i.e. all terms must be satisfied.
-                          items:
-                            description: Defines a set of pods (namely those matching
-                              the labelSelector relative to the given namespace(s))
-                              that this pod should be co-located (affinity) or not
-                              co-located (anti-affinity) with, where co-located is
-                              defined as running on a node whose value of the label
-                              with key <topologyKey> matches that of any node on which
-                              a pod of the set of pods is running
-                            properties:
-                              labelSelector:
-                                description: A label query over a set of resources,
-                                  in this case pods.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                type: object
-                              namespaces:
-                                description: namespaces specifies which namespaces
-                                  the labelSelector applies to (matches against);
-                                  null or empty list means "this pod's namespace"
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                description: This pod should be co-located (affinity)
-                                  or not co-located (anti-affinity) with the pods
-                                  matching the labelSelector in the specified namespaces,
-                                  where co-located is defined as running on a node
-                                  whose value of the label with key topologyKey matches
-                                  that of any node on which any of the selected pods
-                                  is running. Empty topologyKey is not allowed.
-                                type: string
-                            required:
-                            - topologyKey
-                            type: object
-                          type: array
-                      type: object
-                    auxResources:
-                      description: AuxResources are the compute resources required
-                        by the cstor-target pod side car containers.
-                      properties:
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute
-                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute
-                            resources required. If Requests is omitted for a container,
-                            it defaults to Limits if that is explicitly specified,
-                            otherwise to an implementation-defined value. More info:
-                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                      type: object
-                    luWorkers:
-                      description: IOWorkers sets the number of threads that are working
-                        on above queue
-                      format: int64
-                      type: integer
-                    monitor:
-                      description: Monitor enables or disables the target exporter
-                        sidecar
-                      type: boolean
-                    nodeSelector:
-                      additionalProperties:
-                        type: string
-                      description: NodeSelector is the labels that will be used to
-                        select a node for target pod scheduleing Required field
-                      type: object
-                    priorityClassName:
-                      description: PriorityClassName if specified applies to this
-                        target pod If left empty, no priority class is applied.
-                      type: string
-                    queueDepth:
-                      description: QueueDepth sets the queue size at iSCSI target
-                        which limits the ongoing IO count from client
-                      type: string
-                    replicationFactor:
-                      description: ReplicationFactor represents maximum number of
-                        replicas that are allowed to connect to the target
-                      format: int64
-                      type: integer
-                    resources:
-                      description: Resources are the compute resources required by
-                        the cstor-target container.
-                      properties:
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute
-                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute
-                            resources required. If Requests is omitted for a container,
-                            it defaults to Limits if that is explicitly specified,
-                            otherwise to an implementation-defined value. More info:
-                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                      type: object
-                    tolerations:
-                      description: Tolerations, if specified, are the target pod's
-                        tolerations
-                      items:
-                        description: The pod this Toleration is attached to tolerates
-                          any taint that matches the triple <key,value,effect> using
-                          the matching operator <operator>.
-                        properties:
-                          effect:
-                            description: Effect indicates the taint effect to match.
-                              Empty means match all taint effects. When specified,
-                              allowed values are NoSchedule, PreferNoSchedule and
-                              NoExecute.
-                            type: string
-                          key:
-                            description: Key is the taint key that the toleration
-                              applies to. Empty means match all taint keys. If the
-                              key is empty, operator must be Exists; this combination
-                              means to match all values and all keys.
-                            type: string
-                          operator:
-                            description: Operator represents a key's relationship
-                              to the value. Valid operators are Exists and Equal.
-                              Defaults to Equal. Exists is equivalent to wildcard
-                              for value, so that a pod can tolerate all taints of
-                              a particular category.
-                            type: string
-                          tolerationSeconds:
-                            description: TolerationSeconds represents the period of
-                              time the toleration (which must be of effect NoExecute,
-                              otherwise this field is ignored) tolerates the taint.
-                              By default, it is not set, which means tolerate the
-                              taint forever (do not evict). Zero and negative values
-                              will be treated as 0 (evict immediately) by the system.
-                            format: int64
-                            type: integer
-                          value:
-                            description: Value is the taint value the toleration matches
-                              to. If the operator is Exists, the value should be empty,
-                              otherwise just a regular string.
-                            type: string
-                        type: object
-                      type: array
-                  type: object
-              type: object
-            provision:
-              description: Provision represents the initial volume configuration for
-                the underlying cstor volume based on the persistent volume request
-                by user. Provision properties are immutable
-              properties:
-                capacity:
-                  additionalProperties:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  description: Capacity represents initial capacity of volume replica
-                    required during volume clone operations to maintain some metadata
-                    info related to child resources like snapshot, cloned volumes.
-                  type: object
-                replicaCount:
-                  description: ReplicaCount represents initial cstor volume replica
-                    count, its will not be updated later on based on scale up/down
-                    operations, only readonly operations and validations.
-                  type: integer
-              required:
-              - capacity
-              - replicaCount
-              type: object
-          required:
-          - capacity
-          - policy
-          - provision
-          type: object
-        status:
-          description: Status represents the current information/status for the cstor
-            volume config, populated by the controller.
-          properties:
-            capacity:
-              additionalProperties:
-                anyOf:
-                - type: integer
-                - type: string
-                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                x-kubernetes-int-or-string: true
-              description: Capacity the actual resources of the underlying volume.
-              type: object
-            condition:
-              items:
-                description: CStorVolumeConfigCondition contains details about state
-                  of cstor volume
+  versions:
+  - additionalPrinterColumns:
+    - description: Identifies the volume capacity
+      jsonPath: .status.capacity.storage
+      name: Capacity
+      type: string
+    - description: Identifies the volume provisioning status
+      jsonPath: .status.phase
+      name: Status
+      type: string
+    - description: Age of CStorVolumeReplica
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: CStorVolumeConfig describes a cstor volume config resource created
+          as custom resource. CStorVolumeConfig is a request for creating cstor volume
+          related resources like deployment, svc etc.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          publish:
+            description: Publish contains info related to attachment of a volume to
+              a node. i.e. NodeId etc.
+            properties:
+              nodeId:
+                description: NodeID contains publish info related to attachment of
+                  a volume to a node.
+                type: string
+            type: object
+          spec:
+            description: Spec defines a specification of a cstor volume config required
+              to provisione cstor volume resources
+            properties:
+              capacity:
+                additionalProperties:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                description: Capacity represents the actual resources of the underlying
+                  cstor volume.
+                type: object
+              cstorVolumeRef:
+                description: CStorVolumeRef has the information about where CstorVolumeClaim
+                  is created from.
                 properties:
-                  lastProbeTime:
-                    description: Last time we probed the condition.
-                    format: date-time
+                  apiVersion:
+                    description: API version of the referent.
                     type: string
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              cstorVolumeSource:
+                description: CStorVolumeSource contains the source volumeName@snapShotname
+                  combaination.  This will be filled only if it is a clone creation.
+                type: string
+              policy:
+                description: Policy contains volume specific required policies target
+                  and replicas
+                properties:
+                  provision:
+                    description: replicaAffinity is set to true then volume replica
+                      resources need to be distributed across the pool instances
+                    properties:
+                      blockSize:
+                        description: BlockSize is the logical block size in multiple
+                          of 512 bytes BlockSize specifies the block size of the volume.
+                          The blocksize cannot be changed once the volume has been
+                          written, so it should be set at volume creation time. The
+                          default blocksize for volumes is 4 Kbytes. Any power of
+                          2 from 512 bytes to 128 Kbytes is valid.
+                        format: int32
+                        type: integer
+                      replicaAffinity:
+                        description: replicaAffinity is set to true then volume replica
+                          resources need to be distributed across the cstor pool instances
+                          based on the given topology
+                        type: boolean
+                    required:
+                    - replicaAffinity
+                    type: object
+                  replica:
+                    description: ReplicaSpec represents configuration related to replicas
+                      resources
+                    properties:
+                      compression:
+                        description: The zle compression algorithm compresses runs
+                          of zeros.
+                        type: string
+                      zvolWorkers:
+                        description: IOWorkers represents number of threads that executes
+                          client IOs
+                        type: string
+                    type: object
+                  replicaPoolInfo:
+                    description: 'ReplicaPoolInfo holds the pool information of volume
+                      replicas. Ex: If volume is provisioned on which CStor pool volume
+                      replicas exist'
+                    items:
+                      description: ReplicaPoolInfo represents the pool information
+                        of volume replica
+                      properties:
+                        poolName:
+                          description: PoolName represents the pool name where volume
+                            replica exists
+                          type: string
+                      required:
+                      - poolName
+                      type: object
+                    type: array
+                  target:
+                    description: TargetSpec represents configuration related to cstor
+                      target and its resources
+                    properties:
+                      affinity:
+                        description: PodAffinity if specified, are the target pod's
+                          affinities
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the affinity expressions specified
+                              by this field, but it may choose a node that violates
+                              one or more of the expressions. The node that is most
+                              preferred is the one with the greatest sum of weights,
+                              i.e. for each node that meets all of the scheduling
+                              requirements (resource request, requiredDuringScheduling
+                              affinity expressions, etc.), compute a sum by iterating
+                              through the elements of this field and adding "weight"
+                              to the sum if the node has pods which matches the corresponding
+                              podAffinityTerm; the node(s) with the highest sum are
+                              the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the
+                                    corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by
+                              this field are not met at scheduling time, the pod will
+                              not be scheduled onto the node. If the affinity requirements
+                              specified by this field cease to be met at some point
+                              during pod execution (e.g. due to a pod label update),
+                              the system may or may not try to eventually evict the
+                              pod from its node. When there are multiple elements,
+                              the lists of nodes corresponding to each podAffinityTerm
+                              are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s))
+                                that this pod should be co-located (affinity) or not
+                                co-located (anti-affinity) with, where co-located
+                                is defined as running on a node whose value of the
+                                label with key <topologyKey> matches that of any node
+                                on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces
+                                    the labelSelector applies to (matches against);
+                                    null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      auxResources:
+                        description: AuxResources are the compute resources required
+                          by the cstor-target pod side car containers.
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of
+                              compute resources required. If Requests is omitted for
+                              a container, it defaults to Limits if that is explicitly
+                              specified, otherwise to an implementation-defined value.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                        type: object
+                      luWorkers:
+                        description: IOWorkers sets the number of threads that are
+                          working on above queue
+                        format: int64
+                        type: integer
+                      monitor:
+                        description: Monitor enables or disables the target exporter
+                          sidecar
+                        type: boolean
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: NodeSelector is the labels that will be used
+                          to select a node for target pod scheduleing Required field
+                        type: object
+                      priorityClassName:
+                        description: PriorityClassName if specified applies to this
+                          target pod If left empty, no priority class is applied.
+                        type: string
+                      queueDepth:
+                        description: QueueDepth sets the queue size at iSCSI target
+                          which limits the ongoing IO count from client
+                        type: string
+                      replicationFactor:
+                        description: ReplicationFactor represents maximum number of
+                          replicas that are allowed to connect to the target
+                        format: int64
+                        type: integer
+                      resources:
+                        description: Resources are the compute resources required
+                          by the cstor-target container.
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of
+                              compute resources required. If Requests is omitted for
+                              a container, it defaults to Limits if that is explicitly
+                              specified, otherwise to an implementation-defined value.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                        type: object
+                      tolerations:
+                        description: Tolerations, if specified, are the target pod's
+                          tolerations
+                        items:
+                          description: The pod this Toleration is attached to tolerates
+                            any taint that matches the triple <key,value,effect> using
+                            the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match.
+                                Empty means match all taint effects. When specified,
+                                allowed values are NoSchedule, PreferNoSchedule and
+                                NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration
+                                applies to. Empty means match all taint keys. If the
+                                key is empty, operator must be Exists; this combination
+                                means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship
+                                to the value. Valid operators are Exists and Equal.
+                                Defaults to Equal. Exists is equivalent to wildcard
+                                for value, so that a pod can tolerate all taints of
+                                a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period
+                                of time the toleration (which must be of effect NoExecute,
+                                otherwise this field is ignored) tolerates the taint.
+                                By default, it is not set, which means tolerate the
+                                taint forever (do not evict). Zero and negative values
+                                will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration
+                                matches to. If the operator is Exists, the value should
+                                be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              provision:
+                description: Provision represents the initial volume configuration
+                  for the underlying cstor volume based on the persistent volume request
+                  by user. Provision properties are immutable
+                properties:
+                  capacity:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: Capacity represents initial capacity of volume replica
+                      required during volume clone operations to maintain some metadata
+                      info related to child resources like snapshot, cloned volumes.
+                    type: object
+                  replicaCount:
+                    description: ReplicaCount represents initial cstor volume replica
+                      count, its will not be updated later on based on scale up/down
+                      operations, only readonly operations and validations.
+                    type: integer
+                required:
+                - capacity
+                - replicaCount
+                type: object
+            required:
+            - capacity
+            - policy
+            - provision
+            type: object
+          status:
+            description: Status represents the current information/status for the
+              cstor volume config, populated by the controller.
+            properties:
+              capacity:
+                additionalProperties:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                description: Capacity the actual resources of the underlying volume.
+                type: object
+              condition:
+                items:
+                  description: CStorVolumeConfigCondition contains details about state
+                    of cstor volume
+                  properties:
+                    lastProbeTime:
+                      description: Last time we probed the condition.
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: Human-readable message indicating details about
+                        last transition.
+                      type: string
+                    reason:
+                      description: Reason is a brief CamelCase string that describes
+                        any failure
+                      type: string
+                    type:
+                      description: Current Condition of cstor volume config. If underlying
+                        persistent volume is being resized then the Condition will
+                        be set to 'ResizeStarted' etc
+                      type: string
+                  required:
+                  - message
+                  - reason
+                  - type
+                  type: object
+                type: array
+              phase:
+                description: Phase represents the current phase of CStorVolumeConfig.
+                type: string
+              poolInfo:
+                description: PoolInfo represents current pool names where volume replicas
+                  exists
+                items:
+                  type: string
+                type: array
+            type: object
+          versionDetails:
+            description: VersionDetails provides the details for upgrade
+            properties:
+              autoUpgrade:
+                description: If AutoUpgrade is set to true then the resource is upgraded
+                  automatically without any manual steps
+                type: boolean
+              desired:
+                description: Desired is the version that we want to upgrade or the
+                  control plane version
+                type: string
+              status:
+                description: Status gives the status of reconciliation triggered when
+                  the desired and current version are not same
+                properties:
+                  current:
+                    description: Current is the version of resource
+                    type: string
+                  dependentsUpgraded:
+                    description: DependentsUpgraded gives the details whether all
+                      children of a resource are upgraded to desired version or not
+                    type: boolean
+                  lastUpdateTime:
+                    description: LastUpdateTime is the time the status was last  updated
                     format: date-time
+                    nullable: true
                     type: string
                   message:
-                    description: Human-readable message indicating details about last
-                      transition.
+                    description: Message is a human readable message if some error
+                      occurs
                     type: string
                   reason:
-                    description: Reason is a brief CamelCase string that describes
-                      any failure
+                    description: Reason is the actual reason for the error state
                     type: string
-                  type:
-                    description: Current Condition of cstor volume config. If underlying
-                      persistent volume is being resized then the Condition will be
-                      set to 'ResizeStarted' etc
+                  state:
+                    description: State is the state of reconciliation
                     type: string
-                required:
-                - message
-                - reason
-                - type
                 type: object
-              type: array
-            phase:
-              description: Phase represents the current phase of CStorVolumeConfig.
-              type: string
-            poolInfo:
-              description: PoolInfo represents current pool names where volume replicas
-                exists
-              items:
-                type: string
-              type: array
-          type: object
-        versionDetails:
-          description: VersionDetails provides the details for upgrade
-          properties:
-            autoUpgrade:
-              description: If AutoUpgrade is set to true then the resource is upgraded
-                automatically without any manual steps
-              type: boolean
-            desired:
-              description: Desired is the version that we want to upgrade or the control
-                plane version
-              type: string
-            status:
-              description: Status gives the status of reconciliation triggered when
-                the desired and current version are not same
-              properties:
-                current:
-                  description: Current is the version of resource
-                  type: string
-                dependentsUpgraded:
-                  description: DependentsUpgraded gives the details whether all children
-                    of a resource are upgraded to desired version or not
-                  type: boolean
-                lastUpdateTime:
-                  description: LastUpdateTime is the time the status was last  updated
-                  format: date-time
-                  nullable: true
-                  type: string
-                message:
-                  description: Message is a human readable message if some error occurs
-                  type: string
-                reason:
-                  description: Reason is the actual reason for the error state
-                  type: string
-                state:
-                  description: State is the state of reconciliation
-                  type: string
-              type: object
-          type: object
-      required:
-      - spec
-      - status
-      - versionDetails
-      type: object
-  version: v1
-  versions:
-  - name: v1
+            type: object
+        required:
+        - spec
+        - status
+        - versionDetails
+        type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/crds/bases/cstor.openebs.io_cstorvolumepolicies.yaml
+++ b/config/crds/bases/cstor.openebs.io_cstorvolumepolicies.yaml
@@ -1,10 +1,10 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.9
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: cstorvolumepolicies.cstor.openebs.io
 spec:
@@ -16,401 +16,407 @@ spec:
     shortNames:
     - cvp
     singular: cstorvolumepolicy
-  preserveUnknownFields: false
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      description: CStorVolumePolicy describes a configuration required for cstor
-        volume resources
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: Spec defines a configuration info of a cstor volume required
-            to provisione cstor volume resources
-          properties:
-            provision:
-              description: replicaAffinity is set to true then volume replica resources
-                need to be distributed across the pool instances
-              properties:
-                blockSize:
-                  description: BlockSize is the logical block size in multiple of
-                    512 bytes BlockSize specifies the block size of the volume. The
-                    blocksize cannot be changed once the volume has been written,
-                    so it should be set at volume creation time. The default blocksize
-                    for volumes is 4 Kbytes. Any power of 2 from 512 bytes to 128
-                    Kbytes is valid.
-                  format: int32
-                  type: integer
-                replicaAffinity:
-                  description: replicaAffinity is set to true then volume replica
-                    resources need to be distributed across the cstor pool instances
-                    based on the given topology
-                  type: boolean
-              required:
-              - replicaAffinity
-              type: object
-            replica:
-              description: ReplicaSpec represents configuration related to replicas
-                resources
-              properties:
-                compression:
-                  description: The zle compression algorithm compresses runs of zeros.
-                  type: string
-                zvolWorkers:
-                  description: IOWorkers represents number of threads that executes
-                    client IOs
-                  type: string
-              type: object
-            replicaPoolInfo:
-              description: 'ReplicaPoolInfo holds the pool information of volume replicas.
-                Ex: If volume is provisioned on which CStor pool volume replicas exist'
-              items:
-                description: ReplicaPoolInfo represents the pool information of volume
-                  replica
-                properties:
-                  poolName:
-                    description: PoolName represents the pool name where volume replica
-                      exists
-                    type: string
-                required:
-                - poolName
-                type: object
-              type: array
-            target:
-              description: TargetSpec represents configuration related to cstor target
-                and its resources
-              properties:
-                affinity:
-                  description: PodAffinity if specified, are the target pod's affinities
-                  properties:
-                    preferredDuringSchedulingIgnoredDuringExecution:
-                      description: The scheduler will prefer to schedule pods to nodes
-                        that satisfy the affinity expressions specified by this field,
-                        but it may choose a node that violates one or more of the
-                        expressions. The node that is most preferred is the one with
-                        the greatest sum of weights, i.e. for each node that meets
-                        all of the scheduling requirements (resource request, requiredDuringScheduling
-                        affinity expressions, etc.), compute a sum by iterating through
-                        the elements of this field and adding "weight" to the sum
-                        if the node has pods which matches the corresponding podAffinityTerm;
-                        the node(s) with the highest sum are the most preferred.
-                      items:
-                        description: The weights of all of the matched WeightedPodAffinityTerm
-                          fields are added per-node to find the most preferred node(s)
-                        properties:
-                          podAffinityTerm:
-                            description: Required. A pod affinity term, associated
-                              with the corresponding weight.
-                            properties:
-                              labelSelector:
-                                description: A label query over a set of resources,
-                                  in this case pods.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                type: object
-                              namespaces:
-                                description: namespaces specifies which namespaces
-                                  the labelSelector applies to (matches against);
-                                  null or empty list means "this pod's namespace"
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                description: This pod should be co-located (affinity)
-                                  or not co-located (anti-affinity) with the pods
-                                  matching the labelSelector in the specified namespaces,
-                                  where co-located is defined as running on a node
-                                  whose value of the label with key topologyKey matches
-                                  that of any node on which any of the selected pods
-                                  is running. Empty topologyKey is not allowed.
-                                type: string
-                            required:
-                            - topologyKey
-                            type: object
-                          weight:
-                            description: weight associated with matching the corresponding
-                              podAffinityTerm, in the range 1-100.
-                            format: int32
-                            type: integer
-                        required:
-                        - podAffinityTerm
-                        - weight
-                        type: object
-                      type: array
-                    requiredDuringSchedulingIgnoredDuringExecution:
-                      description: If the affinity requirements specified by this
-                        field are not met at scheduling time, the pod will not be
-                        scheduled onto the node. If the affinity requirements specified
-                        by this field cease to be met at some point during pod execution
-                        (e.g. due to a pod label update), the system may or may not
-                        try to eventually evict the pod from its node. When there
-                        are multiple elements, the lists of nodes corresponding to
-                        each podAffinityTerm are intersected, i.e. all terms must
-                        be satisfied.
-                      items:
-                        description: Defines a set of pods (namely those matching
-                          the labelSelector relative to the given namespace(s)) that
-                          this pod should be co-located (affinity) or not co-located
-                          (anti-affinity) with, where co-located is defined as running
-                          on a node whose value of the label with key <topologyKey>
-                          matches that of any node on which a pod of the set of pods
-                          is running
-                        properties:
-                          labelSelector:
-                            description: A label query over a set of resources, in
-                              this case pods.
-                            properties:
-                              matchExpressions:
-                                description: matchExpressions is a list of label selector
-                                  requirements. The requirements are ANDed.
-                                items:
-                                  description: A label selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: key is the label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: operator represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists and DoesNotExist.
-                                      type: string
-                                    values:
-                                      description: values is an array of string values.
-                                        If the operator is In or NotIn, the values
-                                        array must be non-empty. If the operator is
-                                        Exists or DoesNotExist, the values array must
-                                        be empty. This array is replaced during a
-                                        strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchLabels:
-                                additionalProperties:
-                                  type: string
-                                description: matchLabels is a map of {key,value} pairs.
-                                  A single {key,value} in the matchLabels map is equivalent
-                                  to an element of matchExpressions, whose key field
-                                  is "key", the operator is "In", and the values array
-                                  contains only "value". The requirements are ANDed.
-                                type: object
-                            type: object
-                          namespaces:
-                            description: namespaces specifies which namespaces the
-                              labelSelector applies to (matches against); null or
-                              empty list means "this pod's namespace"
-                            items:
-                              type: string
-                            type: array
-                          topologyKey:
-                            description: This pod should be co-located (affinity)
-                              or not co-located (anti-affinity) with the pods matching
-                              the labelSelector in the specified namespaces, where
-                              co-located is defined as running on a node whose value
-                              of the label with key topologyKey matches that of any
-                              node on which any of the selected pods is running. Empty
-                              topologyKey is not allowed.
-                            type: string
-                        required:
-                        - topologyKey
-                        type: object
-                      type: array
-                  type: object
-                auxResources:
-                  description: AuxResources are the compute resources required by
-                    the cstor-target pod side car containers.
-                  properties:
-                    limits:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute
-                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                    requests:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Requests describes the minimum amount of compute
-                        resources required. If Requests is omitted for a container,
-                        it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                  type: object
-                luWorkers:
-                  description: IOWorkers sets the number of threads that are working
-                    on above queue
-                  format: int64
-                  type: integer
-                monitor:
-                  description: Monitor enables or disables the target exporter sidecar
-                  type: boolean
-                nodeSelector:
-                  additionalProperties:
-                    type: string
-                  description: NodeSelector is the labels that will be used to select
-                    a node for target pod scheduleing Required field
-                  type: object
-                priorityClassName:
-                  description: PriorityClassName if specified applies to this target
-                    pod If left empty, no priority class is applied.
-                  type: string
-                queueDepth:
-                  description: QueueDepth sets the queue size at iSCSI target which
-                    limits the ongoing IO count from client
-                  type: string
-                replicationFactor:
-                  description: ReplicationFactor represents maximum number of replicas
-                    that are allowed to connect to the target
-                  format: int64
-                  type: integer
-                resources:
-                  description: Resources are the compute resources required by the
-                    cstor-target container.
-                  properties:
-                    limits:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute
-                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                    requests:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Requests describes the minimum amount of compute
-                        resources required. If Requests is omitted for a container,
-                        it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                  type: object
-                tolerations:
-                  description: Tolerations, if specified, are the target pod's tolerations
-                  items:
-                    description: The pod this Toleration is attached to tolerates
-                      any taint that matches the triple <key,value,effect> using the
-                      matching operator <operator>.
-                    properties:
-                      effect:
-                        description: Effect indicates the taint effect to match. Empty
-                          means match all taint effects. When specified, allowed values
-                          are NoSchedule, PreferNoSchedule and NoExecute.
-                        type: string
-                      key:
-                        description: Key is the taint key that the toleration applies
-                          to. Empty means match all taint keys. If the key is empty,
-                          operator must be Exists; this combination means to match
-                          all values and all keys.
-                        type: string
-                      operator:
-                        description: Operator represents a key's relationship to the
-                          value. Valid operators are Exists and Equal. Defaults to
-                          Equal. Exists is equivalent to wildcard for value, so that
-                          a pod can tolerate all taints of a particular category.
-                        type: string
-                      tolerationSeconds:
-                        description: TolerationSeconds represents the period of time
-                          the toleration (which must be of effect NoExecute, otherwise
-                          this field is ignored) tolerates the taint. By default,
-                          it is not set, which means tolerate the taint forever (do
-                          not evict). Zero and negative values will be treated as
-                          0 (evict immediately) by the system.
-                        format: int64
-                        type: integer
-                      value:
-                        description: Value is the taint value the toleration matches
-                          to. If the operator is Exists, the value should be empty,
-                          otherwise just a regular string.
-                        type: string
-                    type: object
-                  type: array
-              type: object
-          type: object
-        status:
-          description: CStorVolumePolicyStatus is for handling status of CstorVolumePolicy
-          properties:
-            phase:
-              type: string
-          type: object
-      required:
-      - spec
-      type: object
-  version: v1
   versions:
   - name: v1
+    schema:
+      openAPIV3Schema:
+        description: CStorVolumePolicy describes a configuration required for cstor
+          volume resources
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines a configuration info of a cstor volume required
+              to provisione cstor volume resources
+            properties:
+              provision:
+                description: replicaAffinity is set to true then volume replica resources
+                  need to be distributed across the pool instances
+                properties:
+                  blockSize:
+                    description: BlockSize is the logical block size in multiple of
+                      512 bytes BlockSize specifies the block size of the volume.
+                      The blocksize cannot be changed once the volume has been written,
+                      so it should be set at volume creation time. The default blocksize
+                      for volumes is 4 Kbytes. Any power of 2 from 512 bytes to 128
+                      Kbytes is valid.
+                    format: int32
+                    type: integer
+                  replicaAffinity:
+                    description: replicaAffinity is set to true then volume replica
+                      resources need to be distributed across the cstor pool instances
+                      based on the given topology
+                    type: boolean
+                required:
+                - replicaAffinity
+                type: object
+              replica:
+                description: ReplicaSpec represents configuration related to replicas
+                  resources
+                properties:
+                  compression:
+                    description: The zle compression algorithm compresses runs of
+                      zeros.
+                    type: string
+                  zvolWorkers:
+                    description: IOWorkers represents number of threads that executes
+                      client IOs
+                    type: string
+                type: object
+              replicaPoolInfo:
+                description: 'ReplicaPoolInfo holds the pool information of volume
+                  replicas. Ex: If volume is provisioned on which CStor pool volume
+                  replicas exist'
+                items:
+                  description: ReplicaPoolInfo represents the pool information of
+                    volume replica
+                  properties:
+                    poolName:
+                      description: PoolName represents the pool name where volume
+                        replica exists
+                      type: string
+                  required:
+                  - poolName
+                  type: object
+                type: array
+              target:
+                description: TargetSpec represents configuration related to cstor
+                  target and its resources
+                properties:
+                  affinity:
+                    description: PodAffinity if specified, are the target pod's affinities
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces
+                                    the labelSelector applies to (matches against);
+                                    null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to a pod label update), the system may or may
+                          not try to eventually evict the pod from its node. When
+                          there are multiple elements, the lists of nodes corresponding
+                          to each podAffinityTerm are intersected, i.e. all terms
+                          must be satisfied.
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies which namespaces the
+                                labelSelector applies to (matches against); null or
+                                empty list means "this pod's namespace"
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                  auxResources:
+                    description: AuxResources are the compute resources required by
+                      the cstor-target pod side car containers.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  luWorkers:
+                    description: IOWorkers sets the number of threads that are working
+                      on above queue
+                    format: int64
+                    type: integer
+                  monitor:
+                    description: Monitor enables or disables the target exporter sidecar
+                    type: boolean
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: NodeSelector is the labels that will be used to select
+                      a node for target pod scheduleing Required field
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName if specified applies to this target
+                      pod If left empty, no priority class is applied.
+                    type: string
+                  queueDepth:
+                    description: QueueDepth sets the queue size at iSCSI target which
+                      limits the ongoing IO count from client
+                    type: string
+                  replicationFactor:
+                    description: ReplicationFactor represents maximum number of replicas
+                      that are allowed to connect to the target
+                    format: int64
+                    type: integer
+                  resources:
+                    description: Resources are the compute resources required by the
+                      cstor-target container.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  tolerations:
+                    description: Tolerations, if specified, are the target pod's tolerations
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using
+                        the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match.
+                            Empty means match all taint effects. When specified, allowed
+                            values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to
+                            the value. Valid operators are Exists and Equal. Defaults
+                            to Equal. Exists is equivalent to wildcard for value,
+                            so that a pod can tolerate all taints of a particular
+                            category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of
+                            time the toleration (which must be of effect NoExecute,
+                            otherwise this field is ignored) tolerates the taint.
+                            By default, it is not set, which means tolerate the taint
+                            forever (do not evict). Zero and negative values will
+                            be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            type: object
+          status:
+            description: CStorVolumePolicyStatus is for handling status of CstorVolumePolicy
+            properties:
+              phase:
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
     served: true
     storage: true
 status:

--- a/config/crds/bases/cstor.openebs.io_cstorvolumepolicies.yaml
+++ b/config/crds/bases/cstor.openebs.io_cstorvolumepolicies.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: cstorvolumepolicies.cstor.openebs.io
 spec:

--- a/config/crds/bases/cstor.openebs.io_cstorvolumereplicas.yaml
+++ b/config/crds/bases/cstor.openebs.io_cstorvolumereplicas.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: cstorvolumereplicas.cstor.openebs.io
 spec:

--- a/config/crds/bases/cstor.openebs.io_cstorvolumereplicas.yaml
+++ b/config/crds/bases/cstor.openebs.io_cstorvolumereplicas.yaml
@@ -1,30 +1,13 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.9
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: cstorvolumereplicas.cstor.openebs.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.capacity.total
-    description: The amount of disk space consumed by a dataset and all its descendents
-    name: Allocated
-    type: string
-  - JSONPath: .status.capacity.used
-    description: The amount of space that is logically consumed by this dataset
-    name: Used
-    type: string
-  - JSONPath: .status.phase
-    description: Identifies the current state of the replicas
-    name: Status
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: Age of CStorVolumeReplica
-    name: Age
-    type: date
   group: cstor.openebs.io
   names:
     kind: CStorVolumeReplica
@@ -33,182 +16,200 @@ spec:
     shortNames:
     - cvr
     singular: cstorvolumereplica
-  preserveUnknownFields: false
   scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: CStorVolumeReplica describes a cstor volume resource created as
-        custom resource
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: CStorVolumeReplicaSpec is the spec for a CStorVolumeReplica
-            resource
-          properties:
-            blockSize:
-              description: BlockSize is the logical block size in multiple of 512
-                bytes BlockSize specifies the block size of the volume. The blocksize
-                cannot be changed once the volume has been written, so it should be
-                set at volume creation time. The default blocksize for volumes is
-                4 Kbytes. Any power of 2 from 512 bytes to 128 Kbytes is valid.
-              format: int32
-              type: integer
-            capacity:
-              description: Represents the actual capacity of the underlying volume
-              type: string
-            compression:
-              description: 'Controls the compression algorithm used for this volumes
-                examples: on|off|gzip|gzip-N|lz4|lzjb|zle'
-              type: string
-            replicaid:
-              description: ReplicaID is unique number to identify the replica
-              type: string
-            targetIP:
-              description: TargetIP represents iscsi target IP through which replica
-                cummunicates IO workloads and other volume operations like snapshot
-                and resize requests
-              type: string
-            zvolWorkers:
-              description: ZvolWorkers represents number of threads that executes
-                client IOs
-              type: string
-          type: object
-        status:
-          description: CStorVolumeReplicaStatus is for handling status of cvr.
-          properties:
-            capacity:
-              description: CStorVolumeCapacityDetails represents capacity info of
-                replica
-              properties:
-                total:
-                  description: The amount of space consumed by this volume replica
-                    and all its descendents
-                  type: string
-                used:
-                  description: The amount of space that is "logically" accessible
-                    by this dataset. The logical space ignores the effect of the compression
-                    and copies properties, giving a quantity closer to the amount
-                    of data that applications see.  However, it does include space
-                    consumed by metadata
-                  type: string
-              required:
-              - total
-              - used
-              type: object
-            lastTransitionTime:
-              description: LastTransitionTime refers to the time when the phase changes
-              format: date-time
-              nullable: true
-              type: string
-            lastUpdateTime:
-              description: The last updated time
-              format: date-time
-              nullable: true
-              type: string
-            message:
-              description: A human readable message indicating details about the transition.
-              type: string
-            pendingSnapshots:
-              additionalProperties:
-                description: CStorSnapshotInfo represents the snapshot information
-                  related to particular snapshot
-                properties:
-                  logicalReferenced:
-                    description: LogicalReferenced describes the amount of space that
-                      is "logically" accessable by this snapshot. This logical space
-                      ignores the effect of the compression and copies properties,
-                      giving a quantity closer to the amount of data that application
-                      see. It also includes space consumed by metadata.
-                    format: int64
-                    type: integer
-                required:
-                - logicalReferenced
-                type: object
-              description: PendingSnapshots contains list of pending snapshots that
-                are not yet available on this replica
-              type: object
-            phase:
-              description: CStorVolumeReplicaPhase is to holds different phases of
-                replica
-              type: string
-            snapshots:
-              additionalProperties:
-                description: CStorSnapshotInfo represents the snapshot information
-                  related to particular snapshot
-                properties:
-                  logicalReferenced:
-                    description: LogicalReferenced describes the amount of space that
-                      is "logically" accessable by this snapshot. This logical space
-                      ignores the effect of the compression and copies properties,
-                      giving a quantity closer to the amount of data that application
-                      see. It also includes space consumed by metadata.
-                    format: int64
-                    type: integer
-                required:
-                - logicalReferenced
-                type: object
-              description: Snapshots contains list of snapshots, and their properties,
-                created on CVR
-              type: object
-          type: object
-        versionDetails:
-          description: VersionDetails provides the details for upgrade
-          properties:
-            autoUpgrade:
-              description: If AutoUpgrade is set to true then the resource is upgraded
-                automatically without any manual steps
-              type: boolean
-            desired:
-              description: Desired is the version that we want to upgrade or the control
-                plane version
-              type: string
-            status:
-              description: Status gives the status of reconciliation triggered when
-                the desired and current version are not same
-              properties:
-                current:
-                  description: Current is the version of resource
-                  type: string
-                dependentsUpgraded:
-                  description: DependentsUpgraded gives the details whether all children
-                    of a resource are upgraded to desired version or not
-                  type: boolean
-                lastUpdateTime:
-                  description: LastUpdateTime is the time the status was last  updated
-                  format: date-time
-                  nullable: true
-                  type: string
-                message:
-                  description: Message is a human readable message if some error occurs
-                  type: string
-                reason:
-                  description: Reason is the actual reason for the error state
-                  type: string
-                state:
-                  description: State is the state of reconciliation
-                  type: string
-              type: object
-          type: object
-      required:
-      - spec
-      type: object
-  version: v1
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: The amount of disk space consumed by a dataset and all its descendents
+      jsonPath: .status.capacity.total
+      name: Allocated
+      type: string
+    - description: The amount of space that is logically consumed by this dataset
+      jsonPath: .status.capacity.used
+      name: Used
+      type: string
+    - description: Identifies the current state of the replicas
+      jsonPath: .status.phase
+      name: Status
+      type: string
+    - description: Age of CStorVolumeReplica
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: CStorVolumeReplica describes a cstor volume resource created
+          as custom resource
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CStorVolumeReplicaSpec is the spec for a CStorVolumeReplica
+              resource
+            properties:
+              blockSize:
+                description: BlockSize is the logical block size in multiple of 512
+                  bytes BlockSize specifies the block size of the volume. The blocksize
+                  cannot be changed once the volume has been written, so it should
+                  be set at volume creation time. The default blocksize for volumes
+                  is 4 Kbytes. Any power of 2 from 512 bytes to 128 Kbytes is valid.
+                format: int32
+                type: integer
+              capacity:
+                description: Represents the actual capacity of the underlying volume
+                type: string
+              compression:
+                description: 'Controls the compression algorithm used for this volumes
+                  examples: on|off|gzip|gzip-N|lz4|lzjb|zle'
+                type: string
+              replicaid:
+                description: ReplicaID is unique number to identify the replica
+                type: string
+              targetIP:
+                description: TargetIP represents iscsi target IP through which replica
+                  cummunicates IO workloads and other volume operations like snapshot
+                  and resize requests
+                type: string
+              zvolWorkers:
+                description: ZvolWorkers represents number of threads that executes
+                  client IOs
+                type: string
+            type: object
+          status:
+            description: CStorVolumeReplicaStatus is for handling status of cvr.
+            properties:
+              capacity:
+                description: CStorVolumeCapacityDetails represents capacity info of
+                  replica
+                properties:
+                  total:
+                    description: The amount of space consumed by this volume replica
+                      and all its descendents
+                    type: string
+                  used:
+                    description: The amount of space that is "logically" accessible
+                      by this dataset. The logical space ignores the effect of the
+                      compression and copies properties, giving a quantity closer
+                      to the amount of data that applications see.  However, it does
+                      include space consumed by metadata
+                    type: string
+                required:
+                - total
+                - used
+                type: object
+              lastTransitionTime:
+                description: LastTransitionTime refers to the time when the phase
+                  changes
+                format: date-time
+                nullable: true
+                type: string
+              lastUpdateTime:
+                description: The last updated time
+                format: date-time
+                nullable: true
+                type: string
+              message:
+                description: A human readable message indicating details about the
+                  transition.
+                type: string
+              pendingSnapshots:
+                additionalProperties:
+                  description: CStorSnapshotInfo represents the snapshot information
+                    related to particular snapshot
+                  properties:
+                    logicalReferenced:
+                      description: LogicalReferenced describes the amount of space
+                        that is "logically" accessable by this snapshot. This logical
+                        space ignores the effect of the compression and copies properties,
+                        giving a quantity closer to the amount of data that application
+                        see. It also includes space consumed by metadata.
+                      format: int64
+                      type: integer
+                  required:
+                  - logicalReferenced
+                  type: object
+                description: PendingSnapshots contains list of pending snapshots that
+                  are not yet available on this replica
+                type: object
+              phase:
+                description: CStorVolumeReplicaPhase is to holds different phases
+                  of replica
+                type: string
+              snapshots:
+                additionalProperties:
+                  description: CStorSnapshotInfo represents the snapshot information
+                    related to particular snapshot
+                  properties:
+                    logicalReferenced:
+                      description: LogicalReferenced describes the amount of space
+                        that is "logically" accessable by this snapshot. This logical
+                        space ignores the effect of the compression and copies properties,
+                        giving a quantity closer to the amount of data that application
+                        see. It also includes space consumed by metadata.
+                      format: int64
+                      type: integer
+                  required:
+                  - logicalReferenced
+                  type: object
+                description: Snapshots contains list of snapshots, and their properties,
+                  created on CVR
+                type: object
+            type: object
+          versionDetails:
+            description: VersionDetails provides the details for upgrade
+            properties:
+              autoUpgrade:
+                description: If AutoUpgrade is set to true then the resource is upgraded
+                  automatically without any manual steps
+                type: boolean
+              desired:
+                description: Desired is the version that we want to upgrade or the
+                  control plane version
+                type: string
+              status:
+                description: Status gives the status of reconciliation triggered when
+                  the desired and current version are not same
+                properties:
+                  current:
+                    description: Current is the version of resource
+                    type: string
+                  dependentsUpgraded:
+                    description: DependentsUpgraded gives the details whether all
+                      children of a resource are upgraded to desired version or not
+                    type: boolean
+                  lastUpdateTime:
+                    description: LastUpdateTime is the time the status was last  updated
+                    format: date-time
+                    nullable: true
+                    type: string
+                  message:
+                    description: Message is a human readable message if some error
+                      occurs
+                    type: string
+                  reason:
+                    description: Reason is the actual reason for the error state
+                    type: string
+                  state:
+                    description: State is the state of reconciliation
+                    type: string
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/crds/bases/cstor.openebs.io_cstorvolumes.yaml
+++ b/config/crds/bases/cstor.openebs.io_cstorvolumes.yaml
@@ -1,26 +1,13 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.9
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: cstorvolumes.cstor.openebs.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.capacity
-    description: Current volume capacity
-    name: Capacity
-    type: string
-  - JSONPath: .status.phase
-    description: Identifies the current health of the volume
-    name: Status
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: Age of CStorVolume
-    name: Age
-    type: date
   group: cstor.openebs.io
   names:
     kind: CStorVolume
@@ -29,240 +16,255 @@ spec:
     shortNames:
     - cv
     singular: cstorvolume
-  preserveUnknownFields: false
   scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: CStorVolume describes a cstor volume resource created as custom
-        resource
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: CStorVolumeSpec is the spec for a CStorVolume resource
-          properties:
-            capacity:
-              anyOf:
-              - type: integer
-              - type: string
-              description: Capacity represents the desired size of the underlying
-                volume.
-              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-              x-kubernetes-int-or-string: true
-            consistencyFactor:
-              description: ConsistencyFactor is minimum number of volume replicas
-                i.e. `RF/2 + 1` has to be connected to the target for write operations.
-                Basically more then 50% of replica has to be connected to target.
-              type: integer
-            desiredReplicationFactor:
-              description: DesiredReplicationFactor represents maximum number of replicas
-                that are allowed to connect to the target. Required for scale operations
-              type: integer
-            iqn:
-              description: Target iSCSI Qualified Name.combination of nodeBase
-              type: string
-            replicaDetails:
-              description: ReplicaDetails refers to the trusty replica information
-              properties:
-                knownReplicas:
-                  additionalProperties:
-                    type: string
-                  description: KnownReplicas represents the replicas that target can
-                    trust to read data
-                  type: object
-              type: object
-            replicationFactor:
-              description: ReplicationFactor represents number of volume replica created
-                during volume provisioning connect to the target
-              type: integer
-            targetIP:
-              description: TargetIP IP of the iSCSI target service
-              type: string
-            targetPort:
-              description: iSCSI Target Port typically TCP ports 3260
-              type: string
-            targetPortal:
-              description: iSCSI Target Portal. The Portal is combination of IP:port
-                (typically TCP ports 3260)
-              type: string
-          type: object
-        status:
-          description: CStorVolumeStatus is for handling status of cvr.
-          properties:
-            capacity:
-              anyOf:
-              - type: integer
-              - type: string
-              description: Represents the actual capacity of the underlying volume.
-              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-              x-kubernetes-int-or-string: true
-            conditions:
-              description: Current Condition of cstorvolume. If underlying persistent
-                volume is being resized then the Condition will be set to 'ResizePending'.
-              items:
-                description: CStorVolumeCondition contains details about state of
-                  cstorvolume
+  versions:
+  - additionalPrinterColumns:
+    - description: Current volume capacity
+      jsonPath: .status.capacity
+      name: Capacity
+      type: string
+    - description: Identifies the current health of the volume
+      jsonPath: .status.phase
+      name: Status
+      type: string
+    - description: Age of CStorVolume
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: CStorVolume describes a cstor volume resource created as custom
+          resource
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CStorVolumeSpec is the spec for a CStorVolume resource
+            properties:
+              capacity:
+                anyOf:
+                - type: integer
+                - type: string
+                description: Capacity represents the desired size of the underlying
+                  volume.
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+              consistencyFactor:
+                description: ConsistencyFactor is minimum number of volume replicas
+                  i.e. `RF/2 + 1` has to be connected to the target for write operations.
+                  Basically more then 50% of replica has to be connected to target.
+                type: integer
+              desiredReplicationFactor:
+                description: DesiredReplicationFactor represents maximum number of
+                  replicas that are allowed to connect to the target. Required for
+                  scale operations
+                type: integer
+              iqn:
+                description: Target iSCSI Qualified Name.combination of nodeBase
+                type: string
+              replicaDetails:
+                description: ReplicaDetails refers to the trusty replica information
                 properties:
-                  lastProbeTime:
-                    description: Last time we probed the condition.
-                    format: date-time
+                  knownReplicas:
+                    additionalProperties:
+                      type: string
+                    description: KnownReplicas represents the replicas that target
+                      can trust to read data
+                    type: object
+                type: object
+              replicationFactor:
+                description: ReplicationFactor represents number of volume replica
+                  created during volume provisioning connect to the target
+                type: integer
+              targetIP:
+                description: TargetIP IP of the iSCSI target service
+                type: string
+              targetPort:
+                description: iSCSI Target Port typically TCP ports 3260
+                type: string
+              targetPortal:
+                description: iSCSI Target Portal. The Portal is combination of IP:port
+                  (typically TCP ports 3260)
+                type: string
+            type: object
+          status:
+            description: CStorVolumeStatus is for handling status of cvr.
+            properties:
+              capacity:
+                anyOf:
+                - type: integer
+                - type: string
+                description: Represents the actual capacity of the underlying volume.
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+              conditions:
+                description: Current Condition of cstorvolume. If underlying persistent
+                  volume is being resized then the Condition will be set to 'ResizePending'.
+                items:
+                  description: CStorVolumeCondition contains details about state of
+                    cstorvolume
+                  properties:
+                    lastProbeTime:
+                      description: Last time we probed the condition.
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: Human-readable message indicating details about
+                        last transition.
+                      type: string
+                    reason:
+                      description: Unique, this should be a short, machine understandable
+                        string that gives the reason for condition's last transition.
+                        If it reports "ResizePending" that means the underlying cstorvolume
+                        is being resized.
+                      type: string
+                    status:
+                      description: ConditionStatus states in which state condition
+                        is present
+                      type: string
+                    type:
+                      description: CStorVolumeConditionType is a valid value of CStorVolumeCondition.Type
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastTransitionTime:
+                description: LastTransitionTime refers to the time when the phase
+                  changes
+                format: date-time
+                nullable: true
+                type: string
+              lastUpdateTime:
+                description: LastUpdateTime refers to the time when last status updated
+                  due to any operations
+                format: date-time
+                nullable: true
+                type: string
+              message:
+                description: A human-readable message indicating details about why
+                  the volume is in this state.
+                type: string
+              phase:
+                description: CStorVolumePhase is to hold result of action.
+                type: string
+              replicaDetails:
+                description: ReplicaDetails refers to the trusty replica information
+                properties:
+                  knownReplicas:
+                    additionalProperties:
+                      type: string
+                    description: KnownReplicas represents the replicas that target
+                      can trust to read data
+                    type: object
+                type: object
+              replicaStatuses:
+                items:
+                  description: ReplicaStatus stores the status of replicas
+                  properties:
+                    checkpointedIOSeq:
+                      description: Represents IO number of replica persisted on the
+                        disk
+                      type: string
+                    inflightRead:
+                      description: Ongoing reads I/O from target to replica
+                      type: string
+                    inflightSync:
+                      description: Ongoing sync I/O from target to replica
+                      type: string
+                    inflightWrite:
+                      description: ongoing writes I/O from target to replica
+                      type: string
+                    mode:
+                      description: Mode represents replica status i.e. Healthy, Degraded
+                      type: string
+                    quorum:
+                      description: 'Quorum indicates wheather data wrtitten to the
+                        replica is lost or exists. "0" means: data has been lost(
+                        might be ephimeral case) and will recostruct data from other
+                        Healthy replicas in a write-only mode 1 means: written data
+                        is exists on replica'
+                      type: string
+                    replicaId:
+                      description: ID is replica unique identifier
+                      type: string
+                    upTime:
+                      description: time since the replica connected to target
+                      type: integer
+                  required:
+                  - checkpointedIOSeq
+                  - inflightRead
+                  - inflightSync
+                  - inflightWrite
+                  - mode
+                  - quorum
+                  - replicaId
+                  - upTime
+                  type: object
+                type: array
+            type: object
+          versionDetails:
+            description: VersionDetails provides the details for upgrade
+            properties:
+              autoUpgrade:
+                description: If AutoUpgrade is set to true then the resource is upgraded
+                  automatically without any manual steps
+                type: boolean
+              desired:
+                description: Desired is the version that we want to upgrade or the
+                  control plane version
+                type: string
+              status:
+                description: Status gives the status of reconciliation triggered when
+                  the desired and current version are not same
+                properties:
+                  current:
+                    description: Current is the version of resource
                     type: string
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
+                  dependentsUpgraded:
+                    description: DependentsUpgraded gives the details whether all
+                      children of a resource are upgraded to desired version or not
+                    type: boolean
+                  lastUpdateTime:
+                    description: LastUpdateTime is the time the status was last  updated
                     format: date-time
+                    nullable: true
                     type: string
                   message:
-                    description: Human-readable message indicating details about last
-                      transition.
+                    description: Message is a human readable message if some error
+                      occurs
                     type: string
                   reason:
-                    description: Unique, this should be a short, machine understandable
-                      string that gives the reason for condition's last transition.
-                      If it reports "ResizePending" that means the underlying cstorvolume
-                      is being resized.
+                    description: Reason is the actual reason for the error state
                     type: string
-                  status:
-                    description: ConditionStatus states in which state condition is
-                      present
+                  state:
+                    description: State is the state of reconciliation
                     type: string
-                  type:
-                    description: CStorVolumeConditionType is a valid value of CStorVolumeCondition.Type
-                    type: string
-                required:
-                - status
-                - type
                 type: object
-              type: array
-            lastTransitionTime:
-              description: LastTransitionTime refers to the time when the phase changes
-              format: date-time
-              nullable: true
-              type: string
-            lastUpdateTime:
-              description: LastUpdateTime refers to the time when last status updated
-                due to any operations
-              format: date-time
-              nullable: true
-              type: string
-            message:
-              description: A human-readable message indicating details about why the
-                volume is in this state.
-              type: string
-            phase:
-              description: CStorVolumePhase is to hold result of action.
-              type: string
-            replicaDetails:
-              description: ReplicaDetails refers to the trusty replica information
-              properties:
-                knownReplicas:
-                  additionalProperties:
-                    type: string
-                  description: KnownReplicas represents the replicas that target can
-                    trust to read data
-                  type: object
-              type: object
-            replicaStatuses:
-              items:
-                description: ReplicaStatus stores the status of replicas
-                properties:
-                  checkpointedIOSeq:
-                    description: Represents IO number of replica persisted on the
-                      disk
-                    type: string
-                  inflightRead:
-                    description: Ongoing reads I/O from target to replica
-                    type: string
-                  inflightSync:
-                    description: Ongoing sync I/O from target to replica
-                    type: string
-                  inflightWrite:
-                    description: ongoing writes I/O from target to replica
-                    type: string
-                  mode:
-                    description: Mode represents replica status i.e. Healthy, Degraded
-                    type: string
-                  quorum:
-                    description: 'Quorum indicates wheather data wrtitten to the replica
-                      is lost or exists. "0" means: data has been lost( might be ephimeral
-                      case) and will recostruct data from other Healthy replicas in
-                      a write-only mode 1 means: written data is exists on replica'
-                    type: string
-                  replicaId:
-                    description: ID is replica unique identifier
-                    type: string
-                  upTime:
-                    description: time since the replica connected to target
-                    type: integer
-                required:
-                - checkpointedIOSeq
-                - inflightRead
-                - inflightSync
-                - inflightWrite
-                - mode
-                - quorum
-                - replicaId
-                - upTime
-                type: object
-              type: array
-          type: object
-        versionDetails:
-          description: VersionDetails provides the details for upgrade
-          properties:
-            autoUpgrade:
-              description: If AutoUpgrade is set to true then the resource is upgraded
-                automatically without any manual steps
-              type: boolean
-            desired:
-              description: Desired is the version that we want to upgrade or the control
-                plane version
-              type: string
-            status:
-              description: Status gives the status of reconciliation triggered when
-                the desired and current version are not same
-              properties:
-                current:
-                  description: Current is the version of resource
-                  type: string
-                dependentsUpgraded:
-                  description: DependentsUpgraded gives the details whether all children
-                    of a resource are upgraded to desired version or not
-                  type: boolean
-                lastUpdateTime:
-                  description: LastUpdateTime is the time the status was last  updated
-                  format: date-time
-                  nullable: true
-                  type: string
-                message:
-                  description: Message is a human readable message if some error occurs
-                  type: string
-                reason:
-                  description: Reason is the actual reason for the error state
-                  type: string
-                state:
-                  description: State is the state of reconciliation
-                  type: string
-              type: object
-          type: object
-      required:
-      - spec
-      type: object
-  version: v1
-  versions:
-  - name: v1
+            type: object
+        required:
+        - spec
+        type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/crds/bases/cstor.openebs.io_cstorvolumes.yaml
+++ b/config/crds/bases/cstor.openebs.io_cstorvolumes.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: cstorvolumes.cstor.openebs.io
 spec:


### PR DESCRIPTION
**Why we need this change**

We're currently generating and installing `apiextensions.k8s.io/v1beta1` CRDs for mainly for backwards compatibility. The apiextensions API group graduated to v1 as of Kubernetes 1.16, and the v1beta1 version of the group is scheduled to be dropped in an upcoming Kubernetes release (~1.22.x).

At some point (before v1beta1 is dropped for good) we need to updated our generated CRDs to be v1. Also to verify the steps before migrating to v1 so that they are seamless, and there are no hicupps later

Additionally, it'd be nice to take advantage of some of the v1 features, like defaulting etc in coming k8s releases.

**How the change has been tested**
- Use the v1beta1 CRDs to provision a pool and volumes 
- Apply the new `v1` CRDs, verified all the version 

fixes: https://github.com/openebs/openebs/issues/3054

Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>