### PR TITLE
chore(build): setup muse config

### DIFF
--- a/.muse/config.toml
+++ b/.muse/config.toml
@@ -1,0 +1,7 @@
+ignoreRules = [ "G101",
+                "ST1005"
+              ]
+
+ignoreFiles = """
+vendor/**
+"""


### PR DESCRIPTION
Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>

OpenEBS is participating in the KubeCon Bugbash event. As a pre-requisite, muse is set up to identify the issues via static analysis checks that can be fixed by participants. https://www.eventbrite.com/e/cncf-bug-bash-2021-tickets-152369917525

Using this config, the static analysis is skipped on the vendor directory and also ignores the constraint of error messages starting with caps.