### PR TITLE
minor: Add additional builder options for pod and container

### DIFF
--- a/pkg/kubernetes/core/container.go
+++ b/pkg/kubernetes/core/container.go
@@ -120,6 +120,12 @@ func (c *Container) WithEnvsNew(envs []corev1.EnvVar) *Container {
 	return c
 }
 
+// WithTTY sets the tty boolean for container
+func (c *Container) WithTTY(tty bool) *Container {
+	c.TTY = tty
+	return c
+}
+
 // WithEnvs sets the envs of the container
 func (c *Container) WithEnvs(envs []corev1.EnvVar) *Container {
 	c.Env = append(c.Env, envs...)

--- a/pkg/kubernetes/core/pod.go
+++ b/pkg/kubernetes/core/pod.go
@@ -162,6 +162,12 @@ func (p *PodTemplateSpec) WithTolerationsNew(tolerations ...corev1.Toleration) *
 	return p
 }
 
+// WithRestartPolicy sets the restart-policy for pod-spec
+func (p *PodTemplateSpec) WithRestartPolicy(policy corev1.RestartPolicy) *PodTemplateSpec {
+	p.Spec.RestartPolicy = policy
+	return p
+}
+
 // WithContainers builds the list of containerbuilder
 // provided and merges it to the containers field of the podtemplatespec
 func (p *PodTemplateSpec) WithContainers(containersList ...*Container) *PodTemplateSpec {


### PR DESCRIPTION
Additional builder options are required for building upgrade-job in openebsctl
ref: https://github.com/openebs/openebsctl/blob/5687e22c12255ab6ba7a64e3898188bb2fc46d81/pkg/upgrade/jiva.go#L213-L247

Added option to set:
- tty option for container
- restart policy for pods

Signed-off-by: Abhishek-kumar09 <abhimait1909@gmail.com>